### PR TITLE
Adopt the use of a Developer's Certificate of Origin (DCO)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,10 @@ insert_final_newline=true
 max_line_length=100
 trim_trailing_whitespace=true
 
-[COPYING]
+[{COPYING,DCO.txt}]
 indent_size=unset
 indent_style=space
+max_line_length=80
 
 [Makefile]
 indent_style=tab

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # Docs
 !CONTRIBUTING.md
 !COPYING
+!DCO.txt
 !README.md
 !SECURITY.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,13 @@ documentation or code base, tests, bug fixes, and implementations of new feature
 open an issue before making any substantial changes so you can be sure your work won't be rejected.
 But for small changes, such as fixing a typo, you can open a Pull Request directly.
 
-If you decide to make a contribution, please use the following workflow:
+If you decide to make a contribution, please read the [DCO] and use the following workflow:
 
 - Fork the repository.
 - Create a new branch from the latest `main`.
 - Make your changes on the new branch.
-- Commit to the new branch and push the commit(s).
+- Commit, with [signoff], to the new branch and push the commit(s).
 - Open a Pull Request against `main`.
+
+[dco]: ./DCO.txt
+[signoff]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Summary

Adopt the use of a DCO for this project. The DCO text comes from The Linux Foundation, see: https://developercertificate.org/