### PR TITLE
Specify documentation license

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ mitigation process.
 ## License
 
 The software is available under the `GPL-3.0-only` license, see [COPYING] for the full license text.
+The documentation is available under the `GFDL-1.3-or-later` license, see [GNU Free Documentation
+License v1.3] for the full license text.
 
 [`actions/github-script`]: https://github.com/actions/github-script
 [`run:`]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 [argus: a framework for staged static taint analysis of github workflows and actions]:https://www.usenix.org/conference/usenixsecurity23/presentation/muralee
 [blogged about this problem]: https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure/#1-dont-use-syntax-in-the-run-section-to-avoid-unexpected-substitution-behavior
 [copying]: ./COPYING
+[gnu free documentation license v1.3]: https://www.gnu.org/licenses/fdl-1.3.en.html
 [workflow expression]: https://docs.github.com/en/actions/learn-github-actions/expressions


### PR DESCRIPTION
## Summary

Add an explicit license for the documentation text. In line with the software license, the [GNU Free Documentation License](https://www.gnu.org/licenses/fdl-1.3.en.html) is applied to the documentation.