### PR TITLE
Scan Action manifest at the root of a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ and it will report all detected dangerous uses of workflow expressions.
 
 ### Features
 
+- Scan workflow files and action manifests.
 - Report dangerous uses of workflow expressions in [`run:`] directives.
 - Report dangerous uses of workflow expressions in [`actions/github-script`] scripts.
 

--- a/main.go
+++ b/main.go
@@ -82,6 +82,21 @@ func main() {
 }
 
 func run(wd string) error {
+	if data, err := os.ReadFile(path.Join(wd, "action.yml")); err == nil {
+		manifest, err := parseManifest(data)
+		if err != nil {
+			return err
+		}
+
+		problems := processManifest(&manifest)
+		if cnt := len(problems); cnt > 0 {
+			fmt.Printf("Detected %d problem(s) in 'action.yml':\n", cnt)
+			for _, problem := range problems {
+				fmt.Println("  ", problem)
+			}
+		}
+	}
+
 	workflowsDir := path.Join(wd, ".github", "workflows")
 	workflows, err := os.ReadDir(workflowsDir)
 	if err != nil {
@@ -104,7 +119,7 @@ func run(wd string) error {
 			continue
 		}
 
-		workflow, err := parse(data)
+		workflow, err := parseWorkflow(data)
 		if err != nil {
 			fmt.Printf("Could not parse %s: %v\n", entry.Name(), err)
 			continue

--- a/parse.go
+++ b/parse.go
@@ -41,10 +41,27 @@ type StepWith struct {
 	Script string `yaml:"script"`
 }
 
-func parse(data []byte) (workflow Workflow, err error) {
+func parseWorkflow(data []byte) (workflow Workflow, err error) {
 	if err = yaml.Unmarshal(data, &workflow); err != nil {
 		return workflow, fmt.Errorf("could not parse workflow: %v", err)
 	}
 
 	return workflow, nil
+}
+
+type Manifest struct {
+	Runs ManifestRuns `yaml:"runs"`
+}
+
+type ManifestRuns struct {
+	Using string `yaml:"using"`
+	Steps []Step `yaml:"steps"`
+}
+
+func parseManifest(data []byte) (manifest Manifest, err error) {
+	if err = yaml.Unmarshal(data, &manifest); err != nil {
+		return manifest, fmt.Errorf("could not parse manifest: %v", err)
+	}
+
+	return manifest, nil
 }


### PR DESCRIPTION
Closes #5

## Summary

Extend the functionality of the scanner to look for an Action manifest in the root of the repository and, if it exists, parse it (using a specialized parsing function) and process it (using a specialized processing function). The new functionality is tested in line with existing test practices.
