### PR TITLE
Scan a specific file

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,42 @@ func main() {
 }
 
 func run(wd string) (hasProblems bool, err error) {
+	if data, err := os.ReadFile(wd); err == nil {
+		manifest, err := parseManifest(data)
+		if err != nil {
+			return hasProblems, err
+		}
+
+		problems := processManifest(&manifest)
+		if cnt := len(problems); cnt > 0 {
+			fmt.Printf("Detected %d problem(s) in '%s':\n", cnt, wd)
+			for _, problem := range problems {
+				fmt.Println("  ", problem)
+			}
+		}
+
+		if len(problems) > 0 {
+			// don't try to parse the file as an Actions workflow if it was already
+			// successfully analyzed as an Action manifest.
+			return true, nil
+		}
+
+		workflow, err := parseWorkflow(data)
+		if err != nil {
+			return hasProblems, err
+		}
+
+		problems = processWorkflow(&workflow)
+		if cnt := len(problems); cnt > 0 {
+			fmt.Printf("Detected %d problem(s) in '%s':\n", cnt, wd)
+			for _, problem := range problems {
+				fmt.Println("  ", problem)
+			}
+		}
+
+		return len(problems) > 0, nil
+	}
+
 	if data, err := os.ReadFile(path.Join(wd, "action.yml")); err == nil {
 		manifest, err := parseManifest(data)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -130,11 +130,13 @@ func run(target string) (hasProblems bool, err error) {
 			}
 		}
 	} else {
-		if problems, err := tryManifest(target); err != nil {
-			return hasProblems, err
-		} else {
-			hasProblems = len(problems) > 0
-			printProblems(target, problems)
+		if stat.Name() == "action.yml" {
+			if problems, err := tryManifest(target); err != nil {
+				return hasProblems, err
+			} else {
+				hasProblems = len(problems) > 0
+				printProblems(target, problems)
+			}
 		}
 
 		if problems, err := tryWorkflow(target); err != nil {


### PR DESCRIPTION
Closes #6 

## Summary

Extend the functionality of the scanner to support scanning a specific file. This is achieved by first checking if a given path is a file and, if it is, processing it directly as either a manifest or workflow file.