### PR TITLE
Don't exit early if an Action manifest cannot be parsed

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func run(target string) (hasProblems bool, err error) {
 
 	if stat.IsDir() {
 		if problems, err := tryManifest(path.Join(target, "action.yml")); err != nil {
-			return hasProblems, err
+			fmt.Printf("Could not process manifest 'action.yml': %v\n", err)
 		} else {
 			hasProblems = len(problems) > 0
 			printProblems("action.yml", problems)


### PR DESCRIPTION
Relates to #11

## Summary

Update the behavior of the scanner to not stop analyzing a working directory early if an Action manifest failed to parse. This aligns the behavior for Action manifests with that of workflows (the scanner continues if any one workflow fails to parse). This should also improve reports by being able to find dangerous uses of expressions in workflows without having to make sure the Action manifest is valid (mainly useful for analysts).