### PR TITLE
Add support for Action manifest called `action.yaml`

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,8 +106,15 @@ func run(target string) (hasProblems bool, err error) {
 		if problems, err := tryManifest(path.Join(target, "action.yml")); err != nil {
 			fmt.Printf("Could not process manifest 'action.yml': %v\n", err)
 		} else {
-			hasProblems = len(problems) > 0
+			hasProblems = len(problems) > 0 || hasProblems
 			printProblems("action.yml", problems)
+		}
+
+		if problems, err := tryManifest(path.Join(target, "action.yaml")); err != nil {
+			fmt.Printf("Could not process manifest 'action.yaml': %v\n", err)
+		} else {
+			hasProblems = len(problems) > 0 || hasProblems
+			printProblems("action.yaml", problems)
 		}
 
 		workflowsDir := path.Join(target, ".github", "workflows")
@@ -129,23 +136,23 @@ func run(target string) (hasProblems bool, err error) {
 			if problems, err := tryWorkflow(workflowPath); err != nil {
 				fmt.Printf("Could not process workflow %s: %v\n", entry.Name(), err)
 			} else {
-				hasProblems = len(problems) > 0
+				hasProblems = len(problems) > 0 || hasProblems
 				printProblems(entry.Name(), problems)
 			}
 		}
 	} else {
-		if stat.Name() == "action.yml" {
+		if stat.Name() == "action.yml" || stat.Name() == "action.yaml" {
 			if problems, err := tryManifest(target); err != nil {
 				return hasProblems, err
 			} else {
-				hasProblems = len(problems) > 0
+				hasProblems = len(problems) > 0 || hasProblems
 				printProblems(target, problems)
 			}
 		} else {
 			if problems, err := tryWorkflow(target); err != nil {
 				return hasProblems, err
 			} else {
-				hasProblems = len(problems) > 0
+				hasProblems = len(problems) > 0 || hasProblems
 				printProblems(target, problems)
 			}
 		}

--- a/test/args-manifest.txtar
+++ b/test/args-manifest.txtar
@@ -1,9 +1,17 @@
-! exec ades project/action.yml
+# action.yml
+cd project-yml
+! exec ades action.yml
+cmp stdout stdout.txt
+! stderr .
+
+# action.yaml
+cd ../project-yaml
+! exec ades action.yaml
 cmp stdout stdout.txt
 ! stderr .
 
 
--- project/action.yml --
+-- project-yml/action.yml --
 name: Example action
 description: Sample action for testing _ades_
 
@@ -22,7 +30,28 @@ runs:
     run: echo 'Hello world!'
   - name: Unsafe run
     run: echo 'Hello ${{ inputs.name }}'
+-- project-yml/stdout.txt --
+Detected 1 problem(s) in 'action.yml':
+   step 'Unsafe run' has '${{ inputs.name }}' in run
+-- project-yaml/action.yaml --
+name: Example action
+description: Sample action for testing _ades_
 
--- stdout.txt --
-Detected 1 problem(s) in 'project/action.yml':
+inputs:
+  name:
+    description: The name of the person to greet.
+    required: false
+    default: GeT_RiGhT
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+  - name: Safe run
+    run: echo 'Hello world!'
+  - name: Unsafe run
+    run: echo 'Hello ${{ inputs.name }}'
+-- project-yaml/stdout.txt --
+Detected 1 problem(s) in 'action.yaml':
    step 'Unsafe run' has '${{ inputs.name }}' in run

--- a/test/cwd-manifest.txtar
+++ b/test/cwd-manifest.txtar
@@ -1,11 +1,20 @@
-mkdir .github/workflows
+mkdir project-yml/.github/workflows
+mkdir project-yaml/.github/workflows
 
+# action.yml
+cd project-yml
+! exec ades
+cmp stdout stdout.txt
+! stderr .
+
+# action.yaml
+cd ../project-yaml
 ! exec ades
 cmp stdout stdout.txt
 ! stderr .
 
 
--- action.yml --
+-- project-yml/action.yml --
 name: Example action
 description: Sample action for testing _ades_
 
@@ -24,7 +33,28 @@ runs:
     run: echo 'Hello world!'
   - name: Unsafe run
     run: echo 'Hello ${{ inputs.name }}'
-
--- stdout.txt --
+-- project-yml/stdout.txt --
 Detected 1 problem(s) in 'action.yml':
+   step 'Unsafe run' has '${{ inputs.name }}' in run
+-- project-yaml/action.yaml --
+name: Example action
+description: Sample action for testing _ades_
+
+inputs:
+  name:
+    description: The name of the person to greet.
+    required: false
+    default: GeT_RiGhT
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+  - name: Safe run
+    run: echo 'Hello world!'
+  - name: Unsafe run
+    run: echo 'Hello ${{ inputs.name }}'
+-- project-yaml/stdout.txt --
+Detected 1 problem(s) in 'action.yaml':
    step 'Unsafe run' has '${{ inputs.name }}' in run


### PR DESCRIPTION
Closes #16

## Summary

Extend support for manifest scanning to support both the `.yml` and `.yaml` extensions per: <https://docs.github.com/en/actions/creating-actions/about-custom-actions>. CLI tests have been extended to cover `.yaml` extension manifest as well - both for directory and file scanning.
