### PR TITLE
Export & document parsing logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func tryManifest(manifestPath string) (problems []string, err error) {
 		return nil, nil
 	}
 
-	manifest, err := parseManifest(data)
+	manifest, err := ParseManifest(data)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func tryWorkflow(workflowPath string) (problems []string, err error) {
 		return nil, err
 	}
 
-	workflow, err := parseWorkflow(data)
+	workflow, err := ParseWorkflow(data)
 	if err != nil {
 		return nil, err
 	}

--- a/parse.go
+++ b/parse.go
@@ -21,27 +21,32 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Workflow is a (simplified) representation of a GitHub Actions workflow.
 type Workflow struct {
-	Jobs map[string]Job `yaml:"jobs"`
+	Jobs map[string]WorkflowJob `yaml:"jobs"`
 }
 
-type Job struct {
-	Name  string `yaml:"name"`
-	Steps []Step `yaml:"steps"`
+// WorkflowJob is a (simplified) representation of a workflow job.
+type WorkflowJob struct {
+	Name  string    `yaml:"name"`
+	Steps []JobStep `yaml:"steps"`
 }
 
-type Step struct {
+// JobStep is a (simplified) representation of a workflow job step object.
+type JobStep struct {
 	Name string   `yaml:"name"`
 	Run  string   `yaml:"run"`
 	Uses string   `yaml:"uses"`
 	With StepWith `yaml:"with"`
 }
 
+// StepWith is a (simplified) representation of a job step's `with:` object.
 type StepWith struct {
 	Script string `yaml:"script"`
 }
 
-func parseWorkflow(data []byte) (workflow Workflow, err error) {
+// ParseWorkflow parses a GitHub Actions workflow file into a Workflow struct.
+func ParseWorkflow(data []byte) (workflow Workflow, err error) {
 	if err = yaml.Unmarshal(data, &workflow); err != nil {
 		return workflow, fmt.Errorf("could not parse workflow: %v", err)
 	}
@@ -49,16 +54,19 @@ func parseWorkflow(data []byte) (workflow Workflow, err error) {
 	return workflow, nil
 }
 
+// Manifest is a (simplified) representation of a GitHub Actions Action manifest.
 type Manifest struct {
 	Runs ManifestRuns `yaml:"runs"`
 }
 
+// ManifestRuns is a (simplified) representation of an Action manifest's `runs:` object.
 type ManifestRuns struct {
-	Using string `yaml:"using"`
-	Steps []Step `yaml:"steps"`
+	Using string    `yaml:"using"`
+	Steps []JobStep `yaml:"steps"`
 }
 
-func parseManifest(data []byte) (manifest Manifest, err error) {
+// ParseManifest parses a GitHub Actions Action manifest file into a Manifest struct.
+func ParseManifest(data []byte) (manifest Manifest, err error) {
 	if err = yaml.Unmarshal(data, &manifest); err != nil {
 		return manifest, fmt.Errorf("could not parse manifest: %v", err)
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -38,10 +38,10 @@ jobs:
       run: echo '${{ inputs.value }}'
 `,
 			expected: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"example": {
 						Name: "Example",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Checkout repository",
 								Uses: "actions/checkout@v3",
@@ -72,10 +72,10 @@ jobs:
         script: console.log('${{ inputs.value }}')
 `,
 			expected: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"example": {
 						Name: "Example",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Checkout repository",
 								Uses: "actions/checkout@v3",
@@ -104,10 +104,10 @@ jobs:
     - run: echo ${{ inputs.value }}
 `,
 			expected: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"example": {
 						Name: "",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Uses: "actions/setup-node@v3",
 							},
@@ -123,7 +123,7 @@ jobs:
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			workflow, err := parseWorkflow([]byte(tt.yaml))
+			workflow, err := ParseWorkflow([]byte(tt.yaml))
 			if err != nil {
 				t.Fatalf("Unexpected error: %#v", err)
 			}
@@ -199,7 +199,7 @@ jobs:
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parseWorkflow([]byte(tt.yaml))
+			_, err := ParseWorkflow([]byte(tt.yaml))
 			if err == nil {
 				t.Fatal("Expected an error, got none")
 			}
@@ -242,7 +242,7 @@ runs:
 			expected: Manifest{
 				Runs: ManifestRuns{
 					Using: "composite",
-					Steps: []Step{
+					Steps: []JobStep{
 						{
 							Name: "Checkout repository",
 							Uses: "actions/checkout@v3",
@@ -273,7 +273,7 @@ runs:
 			expected: Manifest{
 				Runs: ManifestRuns{
 					Using: "composite",
-					Steps: []Step{
+					Steps: []JobStep{
 						{
 							Name: "Checkout repository",
 							Uses: "actions/checkout@v3",
@@ -293,7 +293,7 @@ runs:
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			manifest, err := parseManifest([]byte(tt.yaml))
+			manifest, err := ParseManifest([]byte(tt.yaml))
 			if err != nil {
 				t.Fatalf("Unexpected error: %#v", err)
 			}
@@ -349,7 +349,7 @@ runs:
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parseManifest([]byte(tt.yaml))
+			_, err := ParseManifest([]byte(tt.yaml))
 			if err == nil {
 				t.Fatal("Expected an error, got none")
 			}

--- a/workflow.go
+++ b/workflow.go
@@ -40,7 +40,7 @@ func processWorkflow(workflow *Workflow) (problems []string) {
 	return problems
 }
 
-func processJob(id string, job *Job) (problems []string) {
+func processJob(id string, job *WorkflowJob) (problems []string) {
 	name := job.Name
 	if name == "" {
 		name = id
@@ -54,7 +54,7 @@ func processJob(id string, job *Job) (problems []string) {
 	return problems
 }
 
-func processSteps(steps []Step) (problems []string) {
+func processSteps(steps []JobStep) (problems []string) {
 	for i, step := range steps {
 		step := step
 		problems = append(problems, processStep(i, &step)...)
@@ -63,7 +63,7 @@ func processSteps(steps []Step) (problems []string) {
 	return problems
 }
 
-func processStep(id int, step *Step) (problems []string) {
+func processStep(id int, step *JobStep) (problems []string) {
 	name := fmt.Sprintf("'%s'", step.Name)
 	if step.Name == "" {
 		name = fmt.Sprintf("#%d", id)
@@ -94,10 +94,10 @@ func processScript(script string) (problems []string) {
 	return problems
 }
 
-func isRunStep(step *Step) bool {
+func isRunStep(step *JobStep) bool {
 	return len(step.Run) > 0
 }
 
-func isActionsGitHubScriptStep(step *Step) bool {
+func isActionsGitHubScriptStep(step *JobStep) bool {
 	return strings.HasPrefix(step.Uses, "actions/github-script@")
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -37,7 +37,7 @@ func TestProcessManifest(t *testing.T) {
 			manifest: Manifest{
 				Runs: ManifestRuns{
 					Using: "composite",
-					Steps: []Step{
+					Steps: []JobStep{
 						{
 							Name: "Example",
 							Run:  "",
@@ -52,7 +52,7 @@ func TestProcessManifest(t *testing.T) {
 			manifest: Manifest{
 				Runs: ManifestRuns{
 					Using: "composite",
-					Steps: []Step{
+					Steps: []JobStep{
 						{
 							Name: "Example unsafe",
 							Run:  "echo ${{ inputs.value }}",
@@ -71,7 +71,7 @@ func TestProcessManifest(t *testing.T) {
 			manifest: Manifest{
 				Runs: ManifestRuns{
 					Using: "composite",
-					Steps: []Step{
+					Steps: []JobStep{
 						{
 							Name: "Example safe",
 							Run:  "echo 'Hello world!'",
@@ -90,7 +90,7 @@ func TestProcessManifest(t *testing.T) {
 			manifest: Manifest{
 				Runs: ManifestRuns{
 					Using: "composite",
-					Steps: []Step{
+					Steps: []JobStep{
 						{
 							Name: "Greeting",
 							Run:  "echo 'Hello ${{ inputs.name }}!'",
@@ -127,10 +127,10 @@ func TestProcessWorkflow(t *testing.T) {
 		{
 			name: "Safe workflow",
 			workflow: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"safe": {
 						Name: "Safe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Example",
 								Run:  "",
@@ -144,10 +144,10 @@ func TestProcessWorkflow(t *testing.T) {
 		{
 			name: "Problem in first of two jobs in workflow",
 			workflow: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"unsafe": {
 						Name: "Unsafe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Example",
 								Run:  "echo ${{ inputs.value }}",
@@ -156,7 +156,7 @@ func TestProcessWorkflow(t *testing.T) {
 					},
 					"safe": {
 						Name: "Safe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Example",
 								Run:  "echo 'Hello world!'",
@@ -170,10 +170,10 @@ func TestProcessWorkflow(t *testing.T) {
 		{
 			name: "Problem in second of two jobs in workflow",
 			workflow: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"safe": {
 						Name: "Safe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Example",
 								Run:  "echo 'Hello world!'",
@@ -182,7 +182,7 @@ func TestProcessWorkflow(t *testing.T) {
 					},
 					"unsafe": {
 						Name: "Unsafe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Example",
 								Run:  "echo ${{ inputs.value }}",
@@ -196,10 +196,10 @@ func TestProcessWorkflow(t *testing.T) {
 		{
 			name: "Problem in all jobs in workflow",
 			workflow: Workflow{
-				Jobs: map[string]Job{
+				Jobs: map[string]WorkflowJob{
 					"unsafe": {
 						Name: "Unsafe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Greeting",
 								Run:  "echo 'Hello ${{ inputs.name }}!'",
@@ -208,7 +208,7 @@ func TestProcessWorkflow(t *testing.T) {
 					},
 					"more-unsafe": {
 						Name: "More Unsafe",
-						Steps: []Step{
+						Steps: []JobStep{
 							{
 								Name: "Example",
 								Run:  "echo ${{ inputs.value }}",
@@ -241,14 +241,14 @@ func TestProcessJob(t *testing.T) {
 	testCases := []struct {
 		name     string
 		id       string
-		job      Job
+		job      WorkflowJob
 		expected int
 	}{
 		{
 			name: "Safe unnamed job",
-			job: Job{
+			job: WorkflowJob{
 				Name: "",
-				Steps: []Step{
+				Steps: []JobStep{
 					{
 						Name: "Unnamed Example",
 						Run:  "",
@@ -259,9 +259,9 @@ func TestProcessJob(t *testing.T) {
 		},
 		{
 			name: "Safe named job",
-			job: Job{
+			job: WorkflowJob{
 				Name: "Safe",
-				Steps: []Step{
+				Steps: []JobStep{
 					{
 						Name: "Named example",
 						Run:  "",
@@ -273,9 +273,9 @@ func TestProcessJob(t *testing.T) {
 		{
 			name: "Unnamed job with unsafe step",
 			id:   "job-id",
-			job: Job{
+			job: WorkflowJob{
 				Name: "",
-				Steps: []Step{
+				Steps: []JobStep{
 					{
 						Name: "Example",
 						Run:  "echo ${{ inputs.value }}",
@@ -286,9 +286,9 @@ func TestProcessJob(t *testing.T) {
 		},
 		{
 			name: "Named job with unsafe step",
-			job: Job{
+			job: WorkflowJob{
 				Name: "Unsafe",
-				Steps: []Step{
+				Steps: []JobStep{
 					{
 						Name: "Example",
 						Run:  "echo ${{ inputs.value }}",
@@ -300,9 +300,9 @@ func TestProcessJob(t *testing.T) {
 		{
 			name: "Unnamed job with unsafe and safe steps",
 			id:   "job-id",
-			job: Job{
+			job: WorkflowJob{
 				Name: "",
-				Steps: []Step{
+				Steps: []JobStep{
 					{
 						Name: "Checkout repository",
 						Run:  "",
@@ -321,9 +321,9 @@ func TestProcessJob(t *testing.T) {
 		},
 		{
 			name: "Named job with unsafe and safe steps",
-			job: Job{
+			job: WorkflowJob{
 				Name: "Unsafe",
-				Steps: []Step{
+				Steps: []JobStep{
 					{
 						Name: "Checkout repository",
 						Run:  "",
@@ -358,14 +358,14 @@ func TestProcessStep(t *testing.T) {
 	type TestCase struct {
 		name     string
 		id       int
-		step     Step
+		step     JobStep
 		expected []string
 	}
 
 	runTestCases := []TestCase{
 		{
 			name: "Unnamed step with no run value",
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Run:  "",
 			},
@@ -373,7 +373,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Named step with no run value",
-			step: Step{
+			step: JobStep{
 				Name: "Doesn't run",
 				Run:  "",
 			},
@@ -381,7 +381,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Unnamed step with safe run value",
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Run:  "echo 'Hello world!'",
 			},
@@ -389,7 +389,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Named step with safe run value",
-			step: Step{
+			step: JobStep{
 				Name: "Run something",
 				Run:  "echo 'Hello world!'",
 			},
@@ -398,7 +398,7 @@ func TestProcessStep(t *testing.T) {
 		{
 			name: "Unnamed run with one expression",
 			id:   42,
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Run:  "echo 'Hello ${{ inputs.name }}!'",
 			},
@@ -408,7 +408,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Named run with one expression",
-			step: Step{
+			step: JobStep{
 				Name: "Greet person",
 				Run:  "echo 'Hello ${{ inputs.name }}!'",
 			},
@@ -419,7 +419,7 @@ func TestProcessStep(t *testing.T) {
 		{
 			name: "Unnamed run with two expressions",
 			id:   3,
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Run:  "echo 'Hello ${{ inputs.name }}! How is your ${{ steps.id.outputs.day }}'",
 			},
@@ -431,7 +431,7 @@ func TestProcessStep(t *testing.T) {
 		{
 			name: "Named run with two expressions",
 			id:   1,
-			step: Step{
+			step: JobStep{
 				Name: "Greet person today",
 				Run:  "echo 'Hello ${{ inputs.name }}! How is your ${{ steps.id.outputs.day }}'",
 			},
@@ -445,7 +445,7 @@ func TestProcessStep(t *testing.T) {
 	actionsGitHubScriptCases := []TestCase{
 		{
 			name: "Unnamed step using another action",
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Uses: "ericcornelissen/non-existent-action",
 			},
@@ -453,7 +453,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Named step using another action",
-			step: Step{
+			step: JobStep{
 				Name: "Doesn't run",
 				Uses: "ericcornelissen/non-existent-action",
 			},
@@ -461,7 +461,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Unnamed step with safe script",
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Uses: "actions/github-script@v6",
 				With: StepWith{
@@ -472,7 +472,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Named step with safe script",
-			step: Step{
+			step: JobStep{
 				Name: "Run something",
 				Uses: "actions/github-script@v6",
 				With: StepWith{
@@ -484,7 +484,7 @@ func TestProcessStep(t *testing.T) {
 		{
 			name: "Unnamed step with unsafe script, one expression",
 			id:   42,
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Uses: "actions/github-script@v6",
 				With: StepWith{
@@ -497,7 +497,7 @@ func TestProcessStep(t *testing.T) {
 		},
 		{
 			name: "Named step with unsafe script, one expression",
-			step: Step{
+			step: JobStep{
 				Name: "Greet person",
 				Uses: "actions/github-script@v6",
 				With: StepWith{
@@ -511,7 +511,7 @@ func TestProcessStep(t *testing.T) {
 		{
 			name: "Unnamed step with unsafe script, two expression",
 			id:   3,
-			step: Step{
+			step: JobStep{
 				Name: "",
 				Uses: "actions/github-script@v6",
 				With: StepWith{
@@ -526,7 +526,7 @@ func TestProcessStep(t *testing.T) {
 		{
 			name: "Named run with two expressions",
 			id:   1,
-			step: Step{
+			step: JobStep{
 				Name: "Greet person today",
 				Uses: "actions/github-script@v6",
 				With: StepWith{


### PR DESCRIPTION
## Summary

Update `parse.go` to intentionally export parsing logic in order to allow re-use of the logic for parsing GitHub Actions workflow and manifest files. Even if incomplete, it may be re-usable, plus I'm willing to expand the structs to allow more use cases (it may come in handy for this project in the future). As exported funcs (and structs), these have been given documentation for completeness.