### PR TITLE
Add suggested fix messaging to tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and it will report all detected dangerous uses of workflow expressions.
 - Scan workflow files and action manifests.
 - Report dangerous uses of workflow expressions in [`run:`] directives.
 - Report dangerous uses of workflow expressions in [`actions/github-script`] scripts.
+- Provides suggested fixes.
 
 ## Background
 

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -406,6 +406,7 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "#42",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInRunScript,
 				},
 			},
 		},
@@ -419,6 +420,7 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "'Greet person'",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInRunScript,
 				},
 			},
 		},
@@ -433,10 +435,12 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "#3",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInRunScript,
 				},
 				{
 					stepId:  "#3",
 					problem: "${{ steps.id.outputs.day }}",
+					kind:    ExpressionInRunScript,
 				},
 			},
 		},
@@ -451,10 +455,12 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "'Greet person today'",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInRunScript,
 				},
 				{
 					stepId:  "'Greet person today'",
 					problem: "${{ steps.id.outputs.day }}",
+					kind:    ExpressionInRunScript,
 				},
 			},
 		},
@@ -513,6 +519,7 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "#42",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInActionsGithubScript,
 				},
 			},
 		},
@@ -529,6 +536,7 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "'Greet person'",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInActionsGithubScript,
 				},
 			},
 		},
@@ -546,10 +554,12 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "#3",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInActionsGithubScript,
 				},
 				{
 					stepId:  "#3",
 					problem: "${{ steps.id.outputs.day }}",
+					kind:    ExpressionInActionsGithubScript,
 				},
 			},
 		},
@@ -567,10 +577,12 @@ func TestProcessStep(t *testing.T) {
 				{
 					stepId:  "'Greet person today'",
 					problem: "${{ inputs.name }}",
+					kind:    ExpressionInActionsGithubScript,
 				},
 				{
 					stepId:  "'Greet person today'",
 					problem: "${{ steps.id.outputs.day }}",
+					kind:    ExpressionInActionsGithubScript,
 				},
 			},
 		},
@@ -590,7 +602,7 @@ func TestProcessStep(t *testing.T) {
 
 			for i, violation := range violations {
 				if got, want := violation, tt.expected[i]; got != want {
-					t.Errorf("Unexpected #%d violation (got '%s', want '%s')", i, got, want)
+					t.Errorf("Unexpected #%d violation (got '%v', want '%v')", i, got, want)
 				}
 			}
 		})

--- a/test/args-manifest.txtar
+++ b/test/args-manifest.txtar
@@ -32,7 +32,10 @@ runs:
     run: echo 'Hello ${{ inputs.name }}'
 -- project-yml/stdout.txt --
 Detected 1 violation(s) in 'action.yml':
-   step 'Unsafe run' has '${{ inputs.name }}'
+  step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)
 -- project-yaml/action.yaml --
 name: Example action
 description: Sample action for testing _ades_
@@ -54,4 +57,7 @@ runs:
     run: echo 'Hello ${{ inputs.name }}'
 -- project-yaml/stdout.txt --
 Detected 1 violation(s) in 'action.yaml':
-   step 'Unsafe run' has '${{ inputs.name }}'
+  step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)

--- a/test/args-multiple.txtar
+++ b/test/args-multiple.txtar
@@ -34,4 +34,7 @@ Scanning project-a
 
 Scanning project-b
 Detected 1 violation(s) in '.github/workflows/unsafe.yml':
-   job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}'
+  job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)

--- a/test/args-workflow.txtar
+++ b/test/args-workflow.txtar
@@ -18,4 +18,7 @@ jobs:
       run: echo 'Hello ${{ inputs.name }}'
 -- stdout.txt --
 Detected 1 violation(s) in 'project/workflow.yml':
-   job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}'
+  job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)

--- a/test/cwd-manifest.txtar
+++ b/test/cwd-manifest.txtar
@@ -32,7 +32,10 @@ runs:
     run: echo 'Hello ${{ inputs.name }}'
 -- project-yml/stdout.txt --
 Detected 1 violation(s) in 'action.yml':
-   step 'Unsafe run' has '${{ inputs.name }}'
+  step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)
 -- project-yaml/action.yaml --
 name: Example action
 description: Sample action for testing _ades_
@@ -54,4 +57,7 @@ runs:
     run: echo 'Hello ${{ inputs.name }}'
 -- project-yaml/stdout.txt --
 Detected 1 violation(s) in 'action.yaml':
-   step 'Unsafe run' has '${{ inputs.name }}'
+  step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)

--- a/test/cwd-workflows.txtar
+++ b/test/cwd-workflows.txtar
@@ -35,4 +35,7 @@ I'm not a workflow and I shouldn't be analyzed.
 print("Beep boop I'm a helper script")
 -- stdout.txt --
 Detected 1 violation(s) in '.github/workflows/unsafe.yml':
-   job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}'
+  job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)

--- a/test/yml-and-yaml.txtar
+++ b/test/yml-and-yaml.txtar
@@ -43,7 +43,13 @@ jobs:
       run: echo 'Hello from .yaml, ${{ inputs.name }}'
 -- yml-stdout.txt --
 Detected 1 violation(s) in '.github/workflows/workflow.yml':
-   job 'Unsafe .yml', step 'Unsafe run' has '${{ inputs.name }}'
+  job 'Unsafe .yml', step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)
 -- yaml-stdout.txt --
 Detected 1 violation(s) in '.github/workflows/workflow.yaml':
-   job 'Unsafe .yaml', step 'Unsafe run' has '${{ inputs.name }}'
+  job 'Unsafe .yaml', step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)


### PR DESCRIPTION
Closes #3

## Summary

Update the tool so that it outputs suggested fixes for violations it finds. This should help users to mitigate any potentially problematic expressions in their workflows or actions manifests. The suggestions seen here are somewhat crude, but should get the job done.

This Pull Request does not cover the _"[...] then outputting the new step as a suggestion."_ part of the issue since that's not as easy to implement (a general transformation, taking into account context such that the script semantics don't change, is non-trivial to define). Instead, I included an example transformation in the documentation.