### PR TITLE
Don't error if `.github/workflows` isn't found

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -138,7 +139,7 @@ func analyzeRepository(target string) (map[string][]Violation, error) {
 
 	workflowsDir := path.Join(target, ".github", "workflows")
 	workflows, err := os.ReadDir(workflowsDir)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return violations, fmt.Errorf("could not read workflows directory: %v", err)
 	}
 

--- a/test/cwd-clean.txtar
+++ b/test/cwd-clean.txtar
@@ -1,5 +1,3 @@
-mkdir .github/workflows
-
 exec ades
 ! stdout .
 ! stderr .

--- a/test/cwd-manifest.txtar
+++ b/test/cwd-manifest.txtar
@@ -1,6 +1,3 @@
-mkdir project-yml/.github/workflows
-mkdir project-yaml/.github/workflows
-
 # action.yml
 cd project-yml
 ! exec ades


### PR DESCRIPTION
## Summary

Scanning a project without workflows should not be considered a problem so if `.github/workflows` does not exist. In that case the CLI should continue running without emitting an error or exiting with an error code.