### PR TITLE
Align documented license with license header & add missing license header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ the mitigation process.
 
 ## License
 
-The software is available under the `GPL-3.0-only` license, see [COPYING.txt] for the full license
-text. The documentation is available under the `GFDL-1.3-or-later` license, see [GNU Free
+The software is available under the `GPL-3.0-or-later` license, see [COPYING.txt] for the full
+license text. The documentation is available under the `GFDL-1.3-or-later` license, see [GNU Free
 Documentation License v1.3] for the full license text.
 
 [`actions/github-script`]: https://github.com/actions/github-script

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,18 @@
+// Copyright (C) 2023  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package main
 
 import (


### PR DESCRIPTION
## Summary

Per the license headers in the `*.go` files (one of which was missing), the license used by this project is `GPL-3.0-or-later` (as opposed to `GPL-3.0-only`) per the inclusion of "or (at your option) any later version." line in the first paragraph.

Note that this is not a license change, but rather a documentation correction. The license file (COPYING.txt for this project) and per-file license headers are authoritative w.r.t. the README.