### PR TITLE
Add machine readable output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 !Makefile
 !go.mod
 !go.sum
+!schema.json
 !*.go
 
 # Test

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ run: ## Run the project on itself
 test: ## Run all tests
 	@echo 'Testing...'
 	@go test .
+	@echo 'Validating JSON schema...'
+	@go run github.com/santhosh-tekuri/jsonschema/cmd/jv@f2cc8ae -assertformat schema.json
 
 .PHONY: vet
 vet: ## Vet the source code

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Documentation License v1.3] for the full license text.
 
 [`actions/github-script`]: https://github.com/actions/github-script
 [`run:`]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+[`schema.json`]: ./schema.json
 [argus: a framework for staged static taint analysis of github workflows and actions]:https://www.usenix.org/conference/usenixsecurity23/presentation/muralee
 [blogged about this problem]: https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure/#1-dont-use-syntax-in-the-run-section-to-avoid-unexpected-substitution-behavior
 [copying.txt]: ./COPYING.txt
 [gnu free documentation license v1.3]: https://www.gnu.org/licenses/fdl-1.3.en.html
 [workflow expression]: https://docs.github.com/en/actions/learn-github-actions/expressions
-[`schema.json`]: ./schema.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and it will report all detected dangerous uses of workflow expressions.
 - Report dangerous uses of workflow expressions in [`run:`] directives.
 - Report dangerous uses of workflow expressions in [`actions/github-script`] scripts.
 - Provides suggested fixes.
+- Machine & human readable output formats.
 
 ### Resolutions
 
@@ -78,6 +79,12 @@ it can be made safer by converting it into:
 #                       | Note: the use of backticks is required in this example (for interpolation)
 ```
 
+### JSON output
+
+The `--json` flag can be used to get the scan results in JSON format. This can be used by machines
+to parse the results to process them for other purposes. The schema is defined in [`schema.json`].
+The schema is intended to be stable from one version to the next for longer periods of time.
+
 ## Background
 
 A [workflow expression] is a string like:
@@ -115,3 +122,4 @@ Documentation License v1.3] for the full license text.
 [copying.txt]: ./COPYING.txt
 [gnu free documentation license v1.3]: https://www.gnu.org/licenses/fdl-1.3.en.html
 [workflow expression]: https://docs.github.com/en/actions/learn-github-actions/expressions
+[`schema.json`]: ./schema.json

--- a/analyze.go
+++ b/analyze.go
@@ -61,7 +61,7 @@ func analyzeJob(id string, job *WorkflowJob) (violations []Violation) {
 	}
 
 	for _, violation := range analyzeSteps(job.Steps) {
-		violation.jobId = fmt.Sprintf("'%s'", name)
+		violation.jobId = name
 		violations = append(violations, violation)
 	}
 
@@ -78,7 +78,7 @@ func analyzeSteps(steps []JobStep) (violations []Violation) {
 }
 
 func analyzeStep(id int, step *JobStep) (violations []Violation) {
-	name := fmt.Sprintf("'%s'", step.Name)
+	name := step.Name
 	if step.Name == "" {
 		name = fmt.Sprintf("#%d", id)
 	}

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -418,7 +418,7 @@ func TestProcessStep(t *testing.T) {
 			},
 			expected: []Violation{
 				{
-					stepId:  "'Greet person'",
+					stepId:  "Greet person",
 					problem: "${{ inputs.name }}",
 					kind:    ExpressionInRunScript,
 				},
@@ -453,12 +453,12 @@ func TestProcessStep(t *testing.T) {
 			},
 			expected: []Violation{
 				{
-					stepId:  "'Greet person today'",
+					stepId:  "Greet person today",
 					problem: "${{ inputs.name }}",
 					kind:    ExpressionInRunScript,
 				},
 				{
-					stepId:  "'Greet person today'",
+					stepId:  "Greet person today",
 					problem: "${{ steps.id.outputs.day }}",
 					kind:    ExpressionInRunScript,
 				},
@@ -534,7 +534,7 @@ func TestProcessStep(t *testing.T) {
 			},
 			expected: []Violation{
 				{
-					stepId:  "'Greet person'",
+					stepId:  "Greet person",
 					problem: "${{ inputs.name }}",
 					kind:    ExpressionInActionsGithubScript,
 				},
@@ -575,12 +575,12 @@ func TestProcessStep(t *testing.T) {
 			},
 			expected: []Violation{
 				{
-					stepId:  "'Greet person today'",
+					stepId:  "Greet person today",
 					problem: "${{ inputs.name }}",
 					kind:    ExpressionInActionsGithubScript,
 				},
 				{
-					stepId:  "'Greet person today'",
+					stepId:  "Greet person today",
 					problem: "${{ steps.id.outputs.day }}",
 					kind:    ExpressionInActionsGithubScript,
 				},

--- a/main.go
+++ b/main.go
@@ -266,9 +266,9 @@ func printViolations(violations map[string][]Violation) {
 
 func printViolation(violation *Violation) {
 	if violation.jobId == "" {
-		fmt.Printf("  step %s has '%s'", violation.stepId, violation.problem)
+		fmt.Printf("  step '%s' has '%s'", violation.stepId, violation.problem)
 	} else {
-		fmt.Printf("  job %s, step %s has '%s'", violation.jobId, violation.stepId, violation.problem)
+		fmt.Printf("  job '%s', step '%s' has '%s'", violation.jobId, violation.stepId, violation.problem)
 	}
 
 	envVarName := getVariableNameForExpression(violation.problem)

--- a/schema.json
+++ b/schema.json
@@ -11,14 +11,17 @@
         "type": "object",
         "additionalProperties": true,
         "properties": {
+          "target": {
+            "type": "string",
+            "description": "The path to the target project that the file is a part of."
+          },
           "file": {
             "type": "string",
             "description": "The workflow or manifest file path."
           },
           "job": {
             "type": "string",
-            "description": "The name or index of a job in the workflow. Missing when the file is a manifest.",
-            "optional": true
+            "description": "The name or index of a job in the workflow. Missing when the file is a manifest."
           },
           "step": {
             "type": "string",
@@ -28,7 +31,13 @@
             "type": "string",
             "description": "The problematic substring."
           }
-        }
+        },
+        "required": [
+          "target",
+          "file",
+          "step",
+          "problem"
+        ]
       }
     }
   }

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "JSON output definition for ades (Actions Dangerous Expressions Scanner)",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "problems": {
+      "type": "array",
+      "description": "Detected violations",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "The workflow or manifest file path."
+          },
+          "job": {
+            "type": "string",
+            "description": "The name or index of a job in the workflow. Missing when the file is a manifest.",
+            "optional": true
+          },
+          "step": {
+            "type": "string",
+            "description": "The name or index of a step in the workflow or manifest."
+          },
+          "problem": {
+            "type": "string",
+            "description": "The problematic substring."
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/json-output.txtar
+++ b/test/json-output.txtar
@@ -1,4 +1,4 @@
-! exec ades -json .github/workflows/workflow.yml
+! exec ades -json .
 cmp stdout stdout.txt
 ! stderr .
 
@@ -16,4 +16,4 @@ jobs:
     - name: Unsafe run
       run: echo 'Hello ${{ inputs.name }}'
 -- stdout.txt --
-{"problems":[{"file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"}]}
+{"problems":[{"target":".","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"}]}

--- a/test/json-output.txtar
+++ b/test/json-output.txtar
@@ -1,0 +1,19 @@
+! exec ades -json .github/workflows/workflow.yml
+cmp stdout stdout.txt
+! stderr .
+
+-- .github/workflows/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Unsafe run
+      run: echo 'Hello ${{ inputs.name }}'
+-- stdout.txt --
+{"problems":[{"file":".github/workflows/workflow.yml","job":"'Example unsafe job'","step":"'Unsafe run'","problem":"${{ inputs.name }}"}]}

--- a/test/json-output.txtar
+++ b/test/json-output.txtar
@@ -16,4 +16,4 @@ jobs:
     - name: Unsafe run
       run: echo 'Hello ${{ inputs.name }}'
 -- stdout.txt --
-{"problems":[{"file":".github/workflows/workflow.yml","job":"'Example unsafe job'","step":"'Unsafe run'","problem":"${{ inputs.name }}"}]}
+{"problems":[{"file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"}]}


### PR DESCRIPTION
Closes #2

## Summary

Add a new flag to the CLI named `-json` which can be used to change the output format to a JSON string that can be used by machines to use the results however they like. The format is explicitly defined in the `schema.json` file.

The implementation differs a bit from the proposal in #2, but I think this is a reasonable implementation that satisfies the request.