### PR TITLE
Add `wrapcheck` and wrap all errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ vet: ## Vet the source code
 	@go run github.com/polyfloyd/go-errorlint@v1.4.5 .
 	@go run github.com/remyoudompheng/go-misc/deadcode@2d6ac65 .
 	@go run github.com/tetafro/godot/cmd/godot@v1.4.15 .
+	@go run github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck@v2.8.1 .
 	@go run golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@2f9d82f .
 	@go run honnef.co/go/tools/cmd/staticcheck@v0.4.6 .
 	@go run mvdan.cc/unparam@3ee2d22 .

--- a/main.go
+++ b/main.go
@@ -249,7 +249,11 @@ func getVariableNameForExpression(expression string) (name string) {
 func getTargets(argv []string) ([]string, error) {
 	if len(argv) == 0 {
 		wd, err := os.Getwd()
-		return []string{wd}, err
+		if err != nil {
+			return nil, fmt.Errorf("could not get cwd: %v", err)
+		}
+
+		return []string{wd}, nil
 	}
 
 	return argv, nil


### PR DESCRIPTION
Relates to #48

## Summary 

Update the `make vet` target to run [wrapcheck] and also wrap all unwrapped errors it detects.

[wrapcheck]: https://github.com/tomarrell/wrapcheck