### PR TITLE
Treat a workflow named `action.ya?ml` consistently

### DIFF
--- a/test/manifest-workflow.txtar
+++ b/test/manifest-workflow.txtar
@@ -1,0 +1,28 @@
+# As part of a repository
+! exec ades .
+cmp stdout stdout.txt
+
+# As a file
+! exec ades .github/workflows/action.yml
+cmp stdout stdout.txt
+
+
+-- .github/workflows/action.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Unsafe run
+      run: echo 'Hello ${{ inputs.name }}'
+-- stdout.txt --
+Detected 1 violation(s) in '.github/workflows/action.yml':
+  job 'Example unsafe job', step 'Unsafe run' has '${{ inputs.name }}', suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)


### PR DESCRIPTION
Closes #35

## Summary

Update the scanner implementation such that a workflow named `action.ya?ml` (i.e. it is in the `.github/workflows` dir) is always analyzed as a workflow. This is achieved by considering the full path of the file when determining whether to scan a given file as a workflow or as a manifest.