### PR TITLE
Add license identifiers to files lacking an explicit license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The maintainers of `ades` welcome contributions and corrections. This includes improvements to the

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-or-later -->
+
 # Actions Dangerous Expressions Scanner
 
 A simple tool to find dangerous uses of GitHub Actions [Workflow expression]s.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the `ades` project take security issues seriously. We appreciate your efforts

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2022 Guilherme J. Tramontina
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 //go:build mutation
 
 package main_test

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "JSON output definition for ades (Actions Dangerous Expressions Scanner)",
+  "license": "CC0-1.0",
   "type": "object",
   "additionalProperties": true,
   "properties": {


### PR DESCRIPTION
Relates to #10, #40

## Summary

Add explicit licenses to files lacking them. Currently out of scope are "configuration" files, for which to me it doesn't seem to make sense to add a license.