### PR TITLE
Vet source code using NilAway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ vet: ## Vet the source code
 	@go run github.com/tetafro/godot/cmd/godot@v1.4.15 .
 	@go run github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck@v2.8.1 .
 	@go run golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@2f9d82f .
+	@go run go.uber.org/nilaway/cmd/nilaway@a267567 .
 	@go run honnef.co/go/tools/cmd/staticcheck@v0.4.6 .
 	@go run mvdan.cc/unparam@3ee2d22 .
 

--- a/analyze.go
+++ b/analyze.go
@@ -38,7 +38,7 @@ type violation struct {
 var r = regexp.MustCompile(`\$\{\{.*?\}\}`)
 
 func analyzeManifest(manifest *Manifest) []violation {
-	if manifest.Runs.Using == "composite" {
+	if manifest != nil && manifest.Runs.Using == "composite" {
 		return analyzeSteps(manifest.Runs.Steps)
 	} else {
 		return make([]violation, 0)
@@ -47,6 +47,10 @@ func analyzeManifest(manifest *Manifest) []violation {
 
 func analyzeWorkflow(workflow *Workflow) []violation {
 	violations := make([]violation, 0)
+	if workflow == nil {
+		return violations
+	}
+
 	for id, job := range workflow.Jobs {
 		job := job
 		violations = append(violations, analyzeJob(id, &job)...)

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -35,6 +35,12 @@ func TestAnalyzeManifest(t *testing.T) {
 			manifest: Manifest{
 				Runs: ManifestRuns{
 					Using: "node16",
+					Steps: []JobStep{
+						{
+							Name: "Example unsafe",
+							Run:  "echo ${{ inputs.value }}",
+						},
+					},
 				},
 			},
 			want: 0,
@@ -123,6 +129,13 @@ func TestAnalyzeManifest(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("nil pointer", func(t *testing.T) {
+		violations := analyzeManifest(nil)
+		if got, want := len(violations), 0; got != want {
+			t.Fatalf("Unexpected number of violations (got %d, want %d)", got, want)
+		}
+	})
 }
 
 func TestAnalyzeWorkflow(t *testing.T) {
@@ -244,6 +257,13 @@ func TestAnalyzeWorkflow(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("nil pointer", func(t *testing.T) {
+		violations := analyzeWorkflow(nil)
+		if got, want := len(violations), 0; got != want {
+			t.Fatalf("Unexpected number of violations (got %d, want %d)", got, want)
+		}
+	})
 }
 
 func TestAnalyzeJob(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -93,11 +93,13 @@ func run() int {
 
 			for file, fileViolations := range targetViolations {
 				if len(fileViolations) > 0 {
-					if _, ok := violations[target]; !ok {
-						violations[target] = make(map[string][]violation)
+					targetViolations, ok := violations[target]
+					if !ok {
+						targetViolations = make(map[string][]violation)
+						violations[target] = targetViolations
 					}
 
-					violations[target][file] = fileViolations
+					targetViolations[file] = fileViolations
 				}
 			}
 		} else {
@@ -310,8 +312,8 @@ func printViolation(v *violation) {
 }
 
 func getVariableNameForExpression(expression string) (name string) {
-	parts := strings.Split(expression, ".")
-	name = strings.TrimRight(parts[len(parts)-1], "}")
+	name = expression[strings.LastIndex(expression, ".")+1:]
+	name = strings.TrimRight(name, "}")
 	name = strings.TrimSpace(name)
 	return strings.ToUpper(name)
 }


### PR DESCRIPTION
Relates to #48, #52, #55

## Summary

Add [NilAway](https://github.com/uber-go/nilaway) as a new vet check in order to detect and address potential runtime errors due to nil values. It found 4 problems as of fa2827488d25057f08109c9808cdf510b2968726, which have all been addressed.

One of the findings was a false positive for which an alternative implementation was feasible (and favorable in terms of memory usage). While the overall assessment as of this Pull Request is that the false positives are tolerable, having false positives is not ideal for a tool that is continuously run. If it turns out to be a problem the continuous usage of NilAway will be reconsidered.