### PR TITLE
Bump Go version to 1.21.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ades
 
-go 1.21.4
+go 1.21.5
 
 require (
 	github.com/gtramontina/ooze v0.2.0


### PR DESCRIPTION
Relates to #66

## Summary

Upgrade to Go version 1.21.5. This follows [GO-2023-2185](https://pkg.go.dev/vuln/GO-2023-2185), a vulnerability in the standard library that affects this project ([per `govulncheck`](https://github.com/ericcornelissen/ades/actions/runs/7122998437/job/19394915219)).