### PR TITLE
Initial support for analyzing from stdin

### DIFF
--- a/test/stdin.txtar
+++ b/test/stdin.txtar
@@ -1,0 +1,94 @@
+# Safe manifest
+stdin safe/action.yml
+exec ades -stdin
+! stdout .
+! stderr .
+
+# Safe workflow
+stdin .github/workflows/safe.yml
+exec ades -stdin
+! stdout .
+! stderr .
+
+# Unsafe manifest
+stdin unsafe/action.yml
+! exec ades -stdin
+cmp stdout stdout-manifest.txt
+! stderr .
+
+# Unsafe workflow
+stdin .github/workflows/unsafe.yml
+! exec ades -stdin
+cmp stdout stdout-workflow.txt
+! stderr .
+
+
+-- safe/action.yml --
+name: Example safe action
+description: Sample action for testing _ades_
+
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+  - name: Safe run
+    run: echo 'Hello world!'
+-- unsafe/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+inputs:
+  name:
+    description: The name of the person to greet.
+    required: false
+    default: GeT_RiGhT
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout repository
+    uses: actions/checkout@v3
+  - name: Safe run
+    run: echo 'Hello world!'
+  - name: Unsafe run
+    run: echo 'Hello ${{ inputs.name }}'
+-- stdout-manifest.txt --
+Detected 1 violation(s) in "stdin":
+  step "Unsafe run" has "${{ inputs.name }}", suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)
+-- .github/workflows/safe.yml --
+name: Example safe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Safe run
+      run: echo 'Hello world!'
+-- .github/workflows/unsafe.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Unsafe run
+      run: echo 'Hello ${{ inputs.name }}'
+-- stdout-workflow.txt --
+Detected 1 violation(s) in "stdin":
+  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}", suggestion:
+    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
+    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
+       (make sure to keep the behavior of the script the same)


### PR DESCRIPTION
Closes #69 

## Summary

Add (and test) support for analyzing a file from stdin. Because we can't know whether the data from stdin is a manifest or workflow, it will be analyzed as both and report violations if either interpretation is problematic.

The behavior is such that if and only if the `-stdin` flag is used, the program will read from stdin. This was chosen because dynamically detecting if there is data on stdin was found to be unreliable. Hence, for now the user needs to be explicit about their intent. If a way is found to reliably detect data on stdin, the implementation can be updated to use that.