### PR TITLE
Define containerized version of the CLI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,32 @@ jobs:
         go-version-file: go.mod
     - name: Build binary
       run: make build
+  container:
+    name: Container
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        engine:
+        - docker
+        - podman
+    needs:
+    - build
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Install Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version-file: go.mod
+    - name: Build container with ${{ matrix.engine }}
+      run: make container
+      env:
+        CONTAINER_ENGINE: ${{ matrix.engine }}
+    - name: Test run container with ${{ matrix.engine }}
+      run: ${CONTAINER_ENGINE} run --rm ericornelissen/ades --help
+      env:
+        CONTAINER_ENGINE: ${{ matrix.engine }}
   format:
     name: Format
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,34 @@ on:
 permissions: read-all
 
 jobs:
+  docker-hub:
+    name: Docker Hub
+    runs-on: ubuntu-22.04
+    environment:
+      name: docker
+      url: https://hub.docker.com/r/ericornelissen/ades
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Get release version
+      id: version
+      shell: bash
+      run: |
+        echo "version=${GITHUB_REF#refs/tags/}" >>"$GITHUB_OUTPUT"
+    - name: Log in to Docker Hub
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Build and push to Docker Hub
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+      with:
+        context: .
+        file: Containerfile
+        push: true
+        tags: >-
+          ericornelissen/js-re-scan:latest,
+          ericornelissen/js-re-scan:${{ steps.version.outputs.version }}
   github-release:
     name: GitHub Release
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 !DCO.txt
 
 # Source
+!Containerfile
 !Makefile
 !go.mod
 !go.sum

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,33 @@
+# Copyright (C) 2023  Eric Cornelissen
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+FROM docker.io/golang:1.21.5 AS build
+
+WORKDIR /src
+COPY Makefile go.mod go.sum *.go ./
+
+RUN make build
+
+# ---
+
+FROM scratch AS main
+
+COPY --from=build /src/ades /bin/ades
+COPY COPYING.txt SECURITY.md /
+
+WORKDIR /src
+VOLUME /src
+
+ENTRYPOINT ["/bin/ades"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CONTAINER_ENGINE?=docker
+CONTAINER_TAG?=latest
 
 .PHONY: default
 default:
@@ -29,7 +30,7 @@ clean: ## Reset the project to a clean state
 container:
 	@$(CONTAINER_ENGINE) build \
 		--file Containerfile \
-		--tag ericornelissen/ades \
+		--tag ericornelissen/ades:$(CONTAINER_TAG) \
 		.
 
 .PHONY: coverage

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CONTAINER_ENGINE?=docker
+
 .PHONY: default
 default:
 	@printf "Usage: make <command>\n\n"
@@ -22,6 +24,13 @@ clean: ## Reset the project to a clean state
 	@git clean -fx \
 		ades \
 		cover.*
+
+.PHONY: container
+container:
+	@$(CONTAINER_ENGINE) build \
+		--file Containerfile \
+		--tag ericornelissen/ades \
+		.
 
 .PHONY: coverage
 coverage: ## Run all tests and generate a coverage report

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ ades .
 
 and it will report all detected dangerous uses of workflow expressions.
 
+You can also use the containerized version of the CLI, for example using Docker:
+
+```shell
+docker run --rm --volume $PWD:/src docker.io/ericornelissen/ades .
+```
+
 ### Features
 
 - Scan workflow files and action manifests.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,5 +64,20 @@ an example):
    "Release {_version_}" (e.g. "Release v23.12"). The release text should be "{_version_}" (e.g.
    "v23.12"). The release artifact should follow the previous release as closely as possible.
 
+1. Publish to [Docker Hub], first with a version tag:
+
+   ```shell
+   make container CONTAINER_TAG=v23.12
+   docker push ericornelissen/ades:v23.12
+   ```
+
+   then the `latest` tag:
+
+   ```shell
+   make container CONTAINER_TAG=latest
+   docker push ericornelissen/ades:latest
+   ```
+
+[docker hub]: https://hub.docker.com/
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [github release]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository


### PR DESCRIPTION
Closes #68 

## Summary

Add a `Containerfile` (engine-agnostic `Dockerfile`) that defines how to build a containerized version of the ades CLI to broaden support (e.g. to those that would like to build from source but don't have the Go toolchain installed).

The Makefile now defines a `make container` target that performs the canonical container build for the project. The README also states that using the container is an option.

## Post-merge

- [ ] Publish containerized version of [v23.11](https://github.com/ericcornelissen/ades/releases/tag/v23.11) (or _latest_) retro-actively so the README.md makes sense.