### PR TITLE
Set up release automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,90 @@
+name: Publish
+on:
+  push:
+    tags:
+    - v[0-9]+.[0-9]+
+
+permissions: read-all
+
+jobs:
+  github-release:
+    name: GitHub Release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write # To create a GitHub Release
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Install Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version-file: go.mod
+    - name: Get release version
+      id: version
+      shell: bash
+      run: |
+        echo "version=${GITHUB_REF#refs/tags/}" >>"$GITHUB_OUTPUT"
+    - name: Compile
+      run: |
+        mkdir _compiled
+
+        # darwin/amd64
+        env GOOS=darwin GOARCH=amd64 go build -o ades
+        tar -czf "ades_darwin_amd64.tar.gz" "ades"
+        mv ades_darwin_amd64.tar.gz _compiled/
+
+        # darwin/arm64
+        env GOOS=darwin GOARCH=arm64 go build -o ades
+        tar -czf "ades_darwin_arm64.tar.gz" "ades"
+        mv ades_darwin_arm64.tar.gz _compiled/
+
+        # linux/386
+        env GOOS=linux GOARCH=386 go build -o ades
+        tar -czf "ades_linux_386.tar.gz" "ades"
+        mv ades_linux_386.tar.gz _compiled/
+
+        # linux/amd64
+        env GOOS=linux GOARCH=amd64 go build -o ades
+        tar -czf "ades_linux_amd64.tar.gz" "ades"
+        mv ades_linux_amd64.tar.gz _compiled/
+
+        # linux/arm
+        env GOOS=linux GOARCH=arm go build -o ades
+        tar -czf "ades_linux_arm.tar.gz" "ades"
+        mv ades_linux_arm.tar.gz _compiled/
+
+        # linux/arm64
+        env GOOS=linux GOARCH=arm64 go build -o ades
+        tar -czf "ades_linux_arm64.tar.gz" "ades"
+        mv ades_linux_arm64.tar.gz _compiled/
+
+        # windows/386
+        env GOOS=windows GOARCH=386 go build -o ades
+        mv ades ades.exe
+        zip -9q "ades_windows_386.zip" "ades.exe"
+        mv ades_windows_386.zip _compiled/
+
+        # windows/amd64
+        env GOOS=windows GOARCH=amd64 go build -o ades
+        mv ades ades.exe
+        zip -9q "ades_windows_amd64.zip" "ades.exe"
+        mv ades_windows_amd64.zip _compiled/
+
+        # windows/arm
+        env GOOS=windows GOARCH=arm go build -o ades
+        mv ades ades.exe
+        zip -9q "ades_windows_arm.zip" "ades.exe"
+        mv ades_windows_arm.zip _compiled/
+
+        # windows/arm64
+        env GOOS=windows GOARCH=arm64 go build -o ades
+        mv ades ades.exe
+        zip -9q "ades_windows_arm64.zip" "ades.exe"
+        mv ades_windows_arm64.zip _compiled/
+    - name: Create GitHub release
+      uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
+      with:
+        tag: ${{ steps.version.outputs.version }}
+        name: Release ${{ steps.version.outputs.version }}
+        body: ${{ steps.version.outputs.version }}
+        artifacts: ./_compiled/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !.github/workflows/audit.yml
 !.github/workflows/check.yml
 !.github/workflows/codeql.yml
+!.github/workflows/publish.yml
 !.github/workflows/semgrep.yml
 !.github/dependabot.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Docs
 !CONTRIBUTING.md
 !README.md
+!RELEASE.md
 !SECURITY.md
 
 # Legal

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,68 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
+# Release Guidelines
+
+To release a new version of the `ades` project follow the steps found in this file (using v23.12 as
+an example):
+
+1. Make sure that your local copy of the repository is up-to-date, sync:
+
+   ```shell
+   git checkout main
+   git pull origin main
+   ```
+
+   Or clone:
+
+   ```shell
+   git clone git@github.com:ericcornelissen/ades.git
+   ```
+
+1. Update the version number following to the current year-month pair in the `version` function in
+   `main.go` (and update the tests correspondingly):
+
+   ```diff
+     func version() {
+   -   fmt.Println("v23.11")
+   +   fmt.Println("v23.12")
+     }
+   ```
+
+   Single-digit months should be prefixed with a `0` (for example for January `24.01`).
+
+1. Commit the changes to a new branch and push using:
+
+   ```shell
+   git checkout -b version-bump
+   git add 'main.go' 'test/flags-info.txtar'
+   git commit --signoff --message 'version bump'
+   git push origin version-bump
+   ```
+
+1. Create a Pull Request to merge the new branch into `main`.
+
+1. Merge the Pull Request if the changes look OK and all continuous integration checks are passing.
+
+1. Immediately after the Pull Request is merged, sync the `main` branch:
+
+   ```shell
+   git checkout main
+   git pull origin main
+   ```
+
+1. Create a [git tag] for the new version and push it:
+
+   ```shell
+   git tag v23.12
+   git push origin v23.12
+   ```
+
+   > **Note** At this point, the continuous delivery automation may pick up and complete the release
+   > process. If not, or only partially, continue following the remaining steps.
+
+1. Create a [GitHub Release] for the [git tag] of the new release. The release title should be
+   "Release {_version_}" (e.g. "Release v23.12"). The release text should be "{_version_}" (e.g.
+   "v23.12"). The release artifact should follow the previous release as closely as possible.
+
+[git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
+[github release]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository


### PR DESCRIPTION
Closes #56

## Summary

Create a new GitHub Actions workflow with a job to create a GitHub Release whenever a release tag (e.g. v23.12) is pushed. The release will be linked to the pushed tag, have a standardized name and description, and include 10 compiled versions of the CLI as artifacts.
