### PR TITLE
Continuously validate JSON data against the schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,6 @@ run: ## Run the project on itself
 test: ## Run all tests
 	@echo 'Testing...'
 	@go test .
-	@echo 'Validating JSON schema...'
-	@go run github.com/santhosh-tekuri/jsonschema/cmd/jv -assertformat schema.json
 
 .PHONY: test-mutation
 test-mutation: ## Run mutation tests

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/polyfloyd/go-errorlint v1.4.5
 	github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e
 	github.com/rogpeppe/go-internal v1.11.0
-	github.com/santhosh-tekuri/jsonschema/cmd/jv v0.6.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/tetafro/godot v1.4.15
 	github.com/tomarrell/wrapcheck/v2 v2.8.1
 	go.uber.org/nilaway v0.0.0-20231117175943-a267567c6fff
@@ -57,7 +57,6 @@ require (
 	github.com/quasilyte/gogrep v0.5.0 // indirect
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,6 @@ github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e h1:eTWZyPUn
 github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e/go.mod h1:80FQABjoFzZ2M5uEa6FUaJYEmqU2UOKojlFVak1UAwI=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/santhosh-tekuri/jsonschema/cmd/jv v0.6.0 h1:cZwlzkrhvGz6S77UVwfhoDMjzOznZX/hNtbNfaWMZg8=
-github.com/santhosh-tekuri/jsonschema/cmd/jv v0.6.0/go.mod h1:dFy6uwRvgnJ2FXCabZwFxFVYCdUP+YNauRqxIRVeZ6w=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/tools.go
+++ b/tools.go
@@ -39,7 +39,6 @@ import (
 	_ "github.com/nishanths/exhaustive/cmd/exhaustive"
 	_ "github.com/polyfloyd/go-errorlint"
 	_ "github.com/remyoudompheng/go-misc/deadcode"
-	_ "github.com/santhosh-tekuri/jsonschema/cmd/jv"
 	_ "github.com/tetafro/godot/cmd/godot"
 	_ "github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck"
 	_ "go.uber.org/nilaway/cmd/nilaway"


### PR DESCRIPTION
Closes #53

## Summary

Add a test that validates arbitrary instances of [`jsonOutput`](https://github.com/ericcornelissen/ades/blob/5f3e22fdfdd482f65dc02c0bfc8b497d65a85a97/main.go#L278-L280) against the schema definition in [`schema.json`](https://github.com/ericcornelissen/ades/blob/5f3e22fdfdd482f65dc02c0bfc8b497d65a85a97/schema.json). This is aimed towards avoiding a situation where the actual JSON outputted by the CLI doesn't match the stated schema.