### PR TITLE
Make suggestions optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !CONTRIBUTING.md
 !README.md
 !RELEASE.md
+!RULES.md
 !SECURITY.md
 
 # Legal

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ docker run --rm --volume $PWD:/src docker.io/ericornelissen/ades .
 - Provides suggested fixes.
 - Machine & human readable output formats.
 
-### Resolutions
+### Rules
 
-#### Expression in `run:` directive
+#### ADES100 - Expression in `run:` directive
 
 When a workflow expression appears in a `run:` directive you can avoid any potential attacks by
 extracting the expression into an environment variable and using the environment variable instead.
@@ -57,7 +57,7 @@ it can be made safer by converting it into:
 #        | Note: the use of double quotes is required in this example (for interpolation)
 ```
 
-#### Expression in `actions/github-script` script
+#### ADES101 - Expression in `actions/github-script` script
 
 When a workflow expression appears in a `actions/github-script` script you can avoid any potential
 attacks by extracting the expression into an environment variable and using the environment variable

--- a/README.md
+++ b/README.md
@@ -30,62 +30,7 @@ docker run --rm --volume $PWD:/src docker.io/ericornelissen/ades .
 
 ### Rules
 
-#### ADES100 - Expression in `run:` directive
-
-When a workflow expression appears in a `run:` directive you can avoid any potential attacks by
-extracting the expression into an environment variable and using the environment variable instead.
-
-For example, given the workflow snippet:
-
-```yaml
-- name: Example step
-  run: |
-    echo 'Hello ${{ inputs.name }}'
-```
-
-it can be made safer by converting it into:
-
-```yaml
-- name: Example step
-  env:
-    NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
-  run: |
-    echo "Hello $NAME"
-#        ^      ^^^^^
-#        |      | Replace the expression with the environment variable
-#        |
-#        | Note: the use of double quotes is required in this example (for interpolation)
-```
-
-#### ADES101 - Expression in `actions/github-script` script
-
-When a workflow expression appears in a `actions/github-script` script you can avoid any potential
-attacks by extracting the expression into an environment variable and using the environment variable
-instead.
-
-For example, given the workflow snippet:
-
-```yaml
-- name: Example step
-  uses: actions/github-script@v6
-  with:
-    script: console.log('Hello ${{ inputs.name }}')
-```
-
-it can be made safer by converting it into:
-
-```yaml
-- name: Example step
-  uses: actions/github-script@v6
-  env:
-    NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
-  with:
-    script: console.log(`Hello ${process.env.NAME}`)
-#                       ^      ^^^^^^^^^^^^^^^^^^^
-#                       |      | Replace the expression with the environment variable
-#                       |
-#                       | Note: the use of backticks is required in this example (for interpolation)
-```
+See [RULES.md].
 
 ### JSON output
 
@@ -130,4 +75,5 @@ Documentation License v1.3] for the full license text.
 [blogged about this problem]: https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure/#1-dont-use-syntax-in-the-run-section-to-avoid-unexpected-substitution-behavior
 [copying.txt]: ./COPYING.txt
 [gnu free documentation license v1.3]: https://www.gnu.org/licenses/fdl-1.3.en.html
+[rules.md]: ./RULES.md
 [workflow expression]: https://docs.github.com/en/actions/learn-github-actions/expressions

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-or-later -->
+
+# Rules
+
+All rules supported by `ades` are listed and explained in this document, including an example of how
+to address it.
+
+## ADES100 - Expression in `run:` directive
+
+When a workflow expression appears in a `run:` directive you can avoid any potential attacks by
+extracting the expression into an environment variable and using the environment variable instead.
+
+For example, given the workflow snippet:
+
+```yaml
+- name: Example step
+  run: |
+    echo 'Hello ${{ inputs.name }}'
+```
+
+it can be made safer by converting it into:
+
+```yaml
+- name: Example step
+  env:
+    NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
+  run: |
+    echo "Hello $NAME"
+#        ^      ^^^^^
+#        |      | Replace the expression with the environment variable
+#        |
+#        | Note: the use of double quotes is required in this example (for interpolation)
+```
+
+## ADES101 - Expression in `actions/github-script` script
+
+When a workflow expression appears in a `actions/github-script` script you can avoid any potential
+attacks by extracting the expression into an environment variable and using the environment variable
+instead.
+
+For example, given the workflow snippet:
+
+```yaml
+- name: Example step
+  uses: actions/github-script@v6
+  with:
+    script: console.log('Hello ${{ inputs.name }}')
+```
+
+it can be made safer by converting it into:
+
+```yaml
+- name: Example step
+  uses: actions/github-script@v6
+  env:
+    NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
+  with:
+    script: console.log(`Hello ${process.env.NAME}`)
+#                       ^      ^^^^^^^^^^^^^^^^^^^
+#                       |      | Replace the expression with the environment variable
+#                       |
+#                       | Note: the use of backticks is required in this example (for interpolation)
+```

--- a/analyze.go
+++ b/analyze.go
@@ -23,6 +23,18 @@ import (
 
 type violationKind uint8
 
+func (kind violationKind) String() string {
+	var s string
+	switch kind {
+	case expressionInRunScript:
+		s = "ADES100"
+	case expressionInActionsGithubScript:
+		s = "ADES101"
+	}
+
+	return s
+}
+
 const (
 	expressionInRunScript violationKind = iota
 	expressionInActionsGithubScript

--- a/analyze.go
+++ b/analyze.go
@@ -23,13 +23,18 @@ import (
 
 type violationKind uint8
 
+var (
+	expressionInRunScriptId           = "ADES100"
+	expressionInActionsGithubScriptId = "ADES101"
+)
+
 func (kind violationKind) String() string {
 	var s string
 	switch kind {
 	case expressionInRunScript:
-		s = "ADES100"
+		s = expressionInRunScriptId
 	case expressionInActionsGithubScript:
-		s = "ADES101"
+		s = expressionInActionsGithubScriptId
 	}
 
 	return s

--- a/explain.go
+++ b/explain.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2023  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import "fmt"
+
+func explain(violationId string) (explanation string, err error) {
+	switch violationId {
+	case expressionInRunScriptId:
+		explanation = explainAdes100()
+	case expressionInActionsGithubScriptId:
+		explanation = explainAdes101()
+	default:
+		err = fmt.Errorf("unknown rule %q", violationId)
+	}
+
+	return explanation, err
+}
+
+func explainAdes100() string {
+	return fmt.Sprintln(`ADES100 - Expression in 'run:' directive
+
+When a workflow expression appears in a 'run:' directive you can avoid any potential attacks by
+extracting the expression into an environment variable and using the environment variable instead.
+
+For example, given the workflow snippet:
+
+    - name: Example step
+      run: |
+        echo 'Hello ${{ inputs.name }}'
+
+it can be made safer by converting it into:
+
+    - name: Example step
+      env:
+        NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
+      run: |
+        echo "Hello $NAME"
+      #      ^      ^^^^^
+      #      |      | Replace the expression with the environment variable
+      #      |
+      #      | Note: the use of double quotes is required in this example (for interpolation)`)
+}
+
+func explainAdes101() string {
+	return fmt.Sprintln(`ADES101 - Expression in 'actions/github-script' script
+
+When a workflow expression appears in a 'actions/github-script' script you can avoid any potential
+attacks by extracting the expression into an environment variable and using the environment variable
+instead.
+
+For example, given the workflow snippet:
+
+    - name: Example step
+      uses: actions/github-script@v6
+      with:
+        script: console.log('Hello ${{ inputs.name }}')
+
+it can be made safer by converting it into:
+
+    - name: Example step
+      uses: actions/github-script@v6
+      env:
+        NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
+      with:
+        script: console.log(` + "`" + `Hello ${process.env.NAME}` + "`" + `)
+      #                     ^      ^^^^^^^^^^^^^^^^^^^
+      #                     |      | Replace the expression with the environment variable
+      #                     |
+      #                     | Note: the use of backticks is required in this example (for interpolation)`)
+}

--- a/explain_test.go
+++ b/explain_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2023  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestExplainRule(t *testing.T) {
+	testCases := []string{
+		expressionInRunScriptId,
+		expressionInActionsGithubScriptId,
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt, func(t *testing.T) {
+			t.Parallel()
+
+			explanation, err := explain(tt)
+			if err != nil {
+				t.Errorf("Unexpected error occurred for %q: %q", tt, err)
+			} else if explanation == "" {
+				t.Errorf("Unexpected empty explanation for %q", tt)
+			}
+		})
+	}
+}
+
+func TestExplainNonRule(t *testing.T) {
+	testCases := []string{
+		"ADES000",
+		"foobar",
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := explain(tt)
+			if err == nil {
+				t.Errorf("Expected an error for %q but got none", tt)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,11 @@ var (
 		false,
 		"Read workflow or manifest from stdin",
 	)
+	flagSuggestions = flag.Bool(
+		"suggestions",
+		false,
+		"Show suggested fixes inline",
+	)
 	flagVersion = flag.Bool(
 		"version",
 		false,
@@ -97,7 +102,7 @@ func run() int {
 				report["stdin"] = violations
 				fmt.Println(printJson(report))
 			} else {
-				fmt.Print(printViolations(violations))
+				fmt.Print(printViolations(violations, *flagSuggestions))
 			}
 
 			return exitViolations
@@ -121,7 +126,7 @@ func run() int {
 		targetViolations, err := analyzeTarget(target)
 		if err == nil {
 			if !(*flagJson) {
-				fmt.Print(printViolations(targetViolations))
+				fmt.Print(printViolations(targetViolations, *flagSuggestions))
 
 				if i < len(targets)-1 {
 					fmt.Println( /* empty line between targets */ )
@@ -303,11 +308,12 @@ Usage:
 
 Flags:
 
-  --help      Show this help message and exit.
-  --json      Output results in JSON format.
-  --legal     Show legal information and exit.
-  --stdin     Read workflow or manifest from stdin.
-  --version   Show the program version and exit.
+  --help          Show this help message and exit.
+  --json          Output results in JSON format.
+  --legal         Show legal information and exit.
+  --stdin         Read workflow or manifest from stdin.
+  --suggestions   Show suggested fixes inline.
+  --version       Show the program version and exit.
 
 Exit Codes:
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,11 @@ const (
 )
 
 var (
+	flagExplain = flag.String(
+		"explain",
+		"",
+		"Explain the given violation",
+	)
 	flagJson = flag.Bool(
 		"json",
 		false,
@@ -77,6 +82,17 @@ func run() int {
 	if *flagVersion {
 		version()
 		return exitSuccess
+	}
+
+	if *flagExplain != "" {
+		explanation, err := explain(*flagExplain)
+		if err != nil {
+			fmt.Printf("Unknown rule %q\n", *flagExplain)
+			return exitError
+		} else {
+			fmt.Print(explanation)
+			return exitSuccess
+		}
 	}
 
 	if *flagStdin {
@@ -308,12 +324,13 @@ Usage:
 
 Flags:
 
-  --help          Show this help message and exit.
-  --json          Output results in JSON format.
-  --legal         Show legal information and exit.
-  --stdin         Read workflow or manifest from stdin.
-  --suggestions   Show suggested fixes inline.
-  --version       Show the program version and exit.
+  --explain ADESxxx   Explain the given violation.
+  --help              Show this help message and exit.
+  --json              Output results in JSON format.
+  --legal             Show legal information and exit.
+  --stdin             Read workflow or manifest from stdin.
+  --suggestions       Show suggested fixes inline.
+  --version           Show the program version and exit.
 
 Exit Codes:
 

--- a/output_test.go
+++ b/output_test.go
@@ -73,6 +73,8 @@ func TestPrintJson(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if got, want := printJson(tt.violations()), tt.want; got != want {
 				t.Fatalf("Unexpected JSON output (got %q, want %q)", got, want)
 			}
@@ -203,6 +205,8 @@ func TestPrintViolations(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if got, want := printViolations(tt.violations(), false), tt.want; got != want {
 				t.Errorf("Unexpected output (got %q, want %q)", got, want)
 			}

--- a/test/explain.txtar
+++ b/test/explain.txtar
@@ -1,0 +1,34 @@
+# Existing rule
+exec ades -explain ADES100
+cmp stdout stdout.txt
+! stderr .
+
+# Non-existent rule
+! exec ades -explain foobar
+stdout 'Unknown rule "foobar"'
+! stderr .
+
+
+-- stdout.txt --
+ADES100 - Expression in 'run:' directive
+
+When a workflow expression appears in a 'run:' directive you can avoid any potential attacks by
+extracting the expression into an environment variable and using the environment variable instead.
+
+For example, given the workflow snippet:
+
+    - name: Example step
+      run: |
+        echo 'Hello ${{ inputs.name }}'
+
+it can be made safer by converting it into:
+
+    - name: Example step
+      env:
+        NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
+      run: |
+        echo "Hello $NAME"
+      #      ^      ^^^^^
+      #      |      | Replace the expression with the environment variable
+      #      |
+      #      | Note: the use of double quotes is required in this example (for interpolation)

--- a/test/stdout.txtar
+++ b/test/stdout.txtar
@@ -34,6 +34,11 @@ stdin project/.github/workflows/workflow.yml
 cmp stdout snapshots/stdin-stdout.txt
 ! stderr .
 
+# suggestions
+! exec ades -suggestions project/.github/workflows/workflow.yml
+cmp stdout snapshots/suggestion-stdout.txt
+! stderr .
+
 
 -- project/action.yml --
 name: Example unsafe action
@@ -85,30 +90,22 @@ jobs:
 {"problems":[{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe GitHub script","problem":"${{ inputs.name }}"},{"target":"project/","file":"action.yml","job":"","step":"Unsafe run","problem":"${{ inputs.name }}"}]}
 -- snapshots/manifest-stdout.txt --
 Detected 1 violation(s) in "project/action.yml":
-  step "Unsafe run" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
-       (make sure to keep the behavior of the script the same)
+  step "Unsafe run" has "${{ inputs.name }}" (ADES100)
 -- snapshots/multiple-stdout.txt --
 Scanning project/action.yml
 Detected 1 violation(s) in "project/action.yml":
-  step "Unsafe run" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
-       (make sure to keep the behavior of the script the same)
+  step "Unsafe run" has "${{ inputs.name }}" (ADES100)
 
 Scanning project/.github/workflows/workflow.yml
 Detected 2 violation(s) in "project/.github/workflows/workflow.yml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
-       (make sure to keep the behavior of the script the same)
-  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `process.env.NAME`
-       (make sure to keep the behavior of the script the same)
+  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
+  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}" (ADES101)
 -- snapshots/stdin-stdout.txt --
 Detected 2 violation(s) in "stdin":
+  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
+  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}" (ADES101)
+-- snapshots/suggestion-stdout.txt --
+Detected 2 violation(s) in "project/.github/workflows/workflow.yml":
   job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}", suggestion:
     1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
     2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
@@ -119,11 +116,5 @@ Detected 2 violation(s) in "stdin":
        (make sure to keep the behavior of the script the same)
 -- snapshots/workflow-stdout.txt --
 Detected 2 violation(s) in "project/.github/workflows/workflow.yml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
-       (make sure to keep the behavior of the script the same)
-  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `process.env.NAME`
-       (make sure to keep the behavior of the script the same)
+  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
+  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}" (ADES101)


### PR DESCRIPTION
Relates to #3 

## Summary

Remove the by-default-outputted suggestions in favor of optional suggestions that can be enabled with the new `--suggestions` flag. When not enabled, the output will instead contain (new) rule IDs, which are (now) present in the documentation and can be used to look up what to do for a given error (just like suggestions). The main motivation for this is to make the output less noisy by default.