### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,11 +8,13 @@ insert_final_newline=true
 max_line_length=100
 trim_trailing_whitespace=true
 
+[Containerfile]
+indent_style=tab
+
 [Makefile]
 indent_style=tab
 
 [*.go]
-indent_size=2
 indent_style=tab
 
 [*.json]


### PR DESCRIPTION
Relates to #57, #81

## Summary

- Add missing entry for `Containerfile`.
- Remove unnecessary `indent_size` for tab indented files.