### PR TITLE
Use `any` and properly name regular expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ coverage: ## Run all tests and generate a coverage report
 .PHONY: fmt fmt-check
 fmt: ## Format the source code
 	@echo 'Formatting...'
-	@go fmt .
+	@gofmt -w .
+	@gofmt -w -r 'interface{} -> any' .
 	@go mod tidy
 	@go run golang.org/x/tools/cmd/goimports -w .
 

--- a/analyze.go
+++ b/analyze.go
@@ -35,7 +35,9 @@ type violation struct {
 	kind    violationKind
 }
 
-var r = regexp.MustCompile(`\$\{\{.*?\}\}`)
+var (
+	ghaExpressionRegExp = regexp.MustCompile(`\$\{\{.*?\}\}`)
+)
 
 func analyzeManifest(manifest *Manifest) []violation {
 	if manifest != nil && manifest.Runs.Using == "composite" {
@@ -103,7 +105,7 @@ func analyzeStep(id int, step *JobStep) []violation {
 
 func analyzeScript(script string) []violation {
 	violations := make([]violation, 0)
-	if matches := r.FindAll([]byte(script), len(script)); matches != nil {
+	if matches := ghaExpressionRegExp.FindAll([]byte(script), len(script)); matches != nil {
 		for _, problem := range matches {
 			violations = append(violations, violation{
 				problem: string(problem),

--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ const (
 )
 
 var (
-	manifestExpr = regexp.MustCompile("action.ya?ml")
+	ghaManifestFileRegExp = regexp.MustCompile("action.ya?ml")
 )
 
 func analyzeRepository(target string) (map[string][]violation, error) {
@@ -250,7 +250,7 @@ func analyzeFile(target string) ([]violation, error) {
 	switch {
 	case strings.HasSuffix(absolutePath, path.Join(githubDir, workflowsDir, path.Base(target))):
 		return tryWorkflow(data)
-	case manifestExpr.MatchString(target):
+	case ghaManifestFileRegExp.MatchString(target):
 		return tryManifest(data)
 	default:
 		return tryWorkflow(data)

--- a/main_test.go
+++ b/main_test.go
@@ -51,7 +51,7 @@ func TestJsonSchema(t *testing.T) {
 			return false
 		}
 
-		var data interface{}
+		var data any
 		if err = json.Unmarshal(bytes, &data); err != nil {
 			return false
 		}


### PR DESCRIPTION
Relates to #22, #60, #74

## Summary

- Adopt the use of the in Go 1.18 introduced `any` alias for `interface{}` which is a more intuitive type name. Also enforce the use of `any` through a [gofmt](https://pkg.go.dev/cmd/gofmt)-based rewrite rule.
- Name constant regular expressions properly and consistently.