### PR TITLE
Use single-dash options for the `ades` binary

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         CONTAINER_ENGINE: ${{ matrix.engine }}
     - name: Test run container with ${{ matrix.engine }}
-      run: ${CONTAINER_ENGINE} run --rm ericornelissen/ades --help
+      run: ${CONTAINER_ENGINE} run --rm ericornelissen/ades -help
       env:
         CONTAINER_ENGINE: ${{ matrix.engine }}
   format:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ See [RULES.md].
 
 ### JSON output
 
-The `--json` flag can be used to get the scan results in JSON format. This can be used by machines
-to parse the results to process them for other purposes. The schema is defined in [`schema.json`].
-The schema is intended to be stable from one version to the next for longer periods of time.
+The `-json` flag can be used to get the scan results in JSON format. This can be used by machines to
+parse the results to process them for other purposes. The schema is defined in [`schema.json`]. The
+schema is intended to be stable from one version to the next for longer periods of time.
 
 ## Background
 

--- a/main.go
+++ b/main.go
@@ -324,13 +324,13 @@ Usage:
 
 Flags:
 
-  --explain ADESxxx   Explain the given violation.
-  --help              Show this help message and exit.
-  --json              Output results in JSON format.
-  --legal             Show legal information and exit.
-  --stdin             Read workflow or manifest from stdin.
-  --suggestions       Show suggested fixes inline.
-  --version           Show the program version and exit.
+  -explain ADESxxx   Explain the given violation.
+  -help              Show this help message and exit.
+  -json              Output results in JSON format.
+  -legal             Show legal information and exit.
+  -stdin             Read workflow or manifest from stdin.
+  -suggestions       Show suggested fixes inline.
+  -version           Show the program version and exit.
 
 Exit Codes:
 

--- a/test/flags-info.txtar
+++ b/test/flags-info.txtar
@@ -1,14 +1,14 @@
-exec ades --help
+exec ades -help
 stdout 'find problematic use of template variables in GitHub Action workflows\n'
 ! stderr .
 
 
-exec ades --legal
+exec ades -legal
 cmp stdout legal-stdout.snapshot
 ! stderr .
 
 
-exec ades --version
+exec ades -version
 stdout 'v23.11'
 ! stderr .
 


### PR DESCRIPTION
## Summary

Prefer single-dash option notation for the `ades` binary as that's more commonly used in the Go ecosystem. Even though this tool isn't meant for the Go ecosystem, just because the docs and related material use a single-dash it is still possible to use double-dash option notation.