### PR TITLE
Test multiple targets with -json flag, make output reproducible

### DIFF
--- a/output.go
+++ b/output.go
@@ -18,6 +18,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -48,6 +49,10 @@ func printJson(rawViolations map[string]map[string][]violation) string {
 			}
 		}
 	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		return violations[i].File < violations[j].File
+	})
 
 	jsonBytes, _ := json.Marshal(jsonOutput{Violations: violations})
 	return string(jsonBytes)

--- a/test/stdout.txtar
+++ b/test/stdout.txtar
@@ -23,6 +23,11 @@ cmp stdout snapshots/json-file-stdout.txt
 cmp stdout snapshots/json-repository-stdout.txt
 ! stderr .
 
+# multiple targets, JSON
+! exec ades -json project/action.yml project/.github/workflows/workflow.yml
+cmp stdout snapshots/json-multiple-stdout.txt
+! stderr .
+
 # stdin
 stdin project/.github/workflows/workflow.yml
 ! exec ades -stdin
@@ -74,8 +79,10 @@ jobs:
         script: console.log("Hello ${{ inputs.name }}");
 -- snapshots/json-file-stdout.txt --
 {"problems":[{"target":"project/.github/workflows/workflow.yml","file":"project/.github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/.github/workflows/workflow.yml","file":"project/.github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe GitHub script","problem":"${{ inputs.name }}"}]}
+-- snapshots/json-multiple-stdout.txt --
+{"problems":[{"target":"project/.github/workflows/workflow.yml","file":"project/.github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/.github/workflows/workflow.yml","file":"project/.github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe GitHub script","problem":"${{ inputs.name }}"},{"target":"project/action.yml","file":"project/action.yml","job":"","step":"Unsafe run","problem":"${{ inputs.name }}"}]}
 -- snapshots/json-repository-stdout.txt --
-{"problems":[{"target":"project/","file":"action.yml","job":"","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe GitHub script","problem":"${{ inputs.name }}"}]}
+{"problems":[{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe GitHub script","problem":"${{ inputs.name }}"},{"target":"project/","file":"action.yml","job":"","step":"Unsafe run","problem":"${{ inputs.name }}"}]}
 -- snapshots/manifest-stdout.txt --
 Detected 1 violation(s) in "project/action.yml":
   step "Unsafe run" has "${{ inputs.name }}", suggestion:


### PR DESCRIPTION
Relates to #61

## Summary

Fix the test suite following the extraction of the output logic which introduced a regression related to the `-json` flag. Working on this also uncovered that the output of the `-json` flag was not reproducible: the ordering of JSON array elements could be arbitrary. This is solved by sorting it by the file name.