### PR TITLE
Disable verbose logging when running mutation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test: ## Run all tests
 .PHONY: test-mutation
 test-mutation: ## Run mutation tests
 	@echo 'Mutation testing...'
-	@go test -v -tags=mutation
+	@go test -tags=mutation
 
 .PHONY: test-randomized
 test-randomized: ## Run tests in a random order


### PR DESCRIPTION
Relates to #51

## Summary

Update the `test-mutation` command to no longer use verbose logging. This follows the continuous integration reporting on the errors produced as part of the logs due to (eliminated) mutants.