### PR TITLE
Detect use of expression on known vulnerable inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ docker run --rm --volume $PWD:/src docker.io/ericornelissen/ades .
 - Scan workflow files and action manifests.
 - Report dangerous uses of workflow expressions in [`run:`] directives.
 - Report dangerous uses of workflow expressions in [`actions/github-script`] scripts.
+- _(Experimental)_ Report dangerous uses of workflow expressions in known vulnerable actions.
 - Provides suggested fixes.
 - Machine & human readable output formats.
 

--- a/RULES.md
+++ b/RULES.md
@@ -61,3 +61,11 @@ it can be made safer by converting it into:
 #                       |
 #                       | Note: the use of backticks is required in this example (for interpolation)
 ```
+
+## ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
+
+When a workflow expression is used in the tag input for `ericcornelissen/git-tag-annotation-action`
+in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see [GHSA-hgx2-4pp9-357g].
+To avoid this, upgrade the action to a non-vulnerable version.
+
+[GHSA-hgx2-4pp9-357g]: https://github.com/ericcornelissen/git-tag-annotation-action/security/advisories/GHSA-hgx2-4pp9-357g

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -638,9 +638,80 @@ func TestAnalyzeStep(t *testing.T) {
 		},
 	}
 
+	actionTestCases := []TestCase{
+		{
+			name: "git-tag-annotation-action, vulnerable version",
+			step: JobStep{
+				Name: "Vulnerable",
+				Uses: "ericcornelissen/git-tag-annotation-action@v1.0.0",
+				With: StepWith{
+					Tag: "${{ inputs.tag }}",
+				},
+			},
+			want: []violation{
+				{
+					stepId:  "Vulnerable",
+					problem: "${{ inputs.tag }}",
+					kind:    expressionInGitTagAnnotationActionTagInput,
+				},
+			},
+		},
+		{
+			name: "git-tag-annotation-action, old version",
+			step: JobStep{
+				Name: "Old",
+				Uses: "ericcornelissen/git-tag-annotation-action@v0.0.9",
+				With: StepWith{
+					Tag: "${{ inputs.tag }}",
+				},
+			},
+			want: []violation{
+				{
+					stepId:  "Old",
+					problem: "${{ inputs.tag }}",
+					kind:    expressionInGitTagAnnotationActionTagInput,
+				},
+			},
+		},
+		{
+			name: "git-tag-annotation-action, fixed version",
+			step: JobStep{
+				Name: "Fixed",
+				Uses: "ericcornelissen/git-tag-annotation-action@v1.0.1",
+				With: StepWith{
+					Tag: "${{ inputs.tag }}",
+				},
+			},
+			want: []violation{},
+		},
+		{
+			name: "git-tag-annotation-action, SHA pin (unsupported)",
+			step: JobStep{
+				Name: "SHA for v1.0.1",
+				Uses: "ericcornelissen/git-tag-annotation-action@21fa0360d55070a1d6b999d027db44cc21a7b48d",
+				With: StepWith{
+					Tag: "${{ inputs.tag }}",
+				},
+			},
+			want: []violation{},
+		},
+		{
+			name: "git-tag-annotation-action, unpinned major version (unsupported)",
+			step: JobStep{
+				Name: "v1",
+				Uses: "ericcornelissen/git-tag-annotation-action@v1",
+				With: StepWith{
+					Tag: "${{ inputs.tag }}",
+				},
+			},
+			want: []violation{},
+		},
+	}
+
 	var allTestCases []TestCase
 	allTestCases = append(allTestCases, runTestCases...)
 	allTestCases = append(allTestCases, actionsGitHubScriptCases...)
+	allTestCases = append(allTestCases, actionTestCases...)
 
 	for _, tt := range allTestCases {
 		tt := tt

--- a/explain.go
+++ b/explain.go
@@ -23,6 +23,8 @@ func explain(violationId string) (explanation string, err error) {
 		explanation = explainAdes100()
 	case expressionInActionsGithubScriptId:
 		explanation = explainAdes101()
+	case expressionInGitTagAnnotationActionTagInputId:
+		explanation = explainAdes200()
 	default:
 		err = fmt.Errorf("unknown rule %q", violationId)
 	}
@@ -81,4 +83,12 @@ it can be made safer by converting it into:
       #                     |      | Replace the expression with the environment variable
       #                     |
       #                     | Note: the use of backticks is required in this example (for interpolation)`)
+}
+
+func explainAdes200() string {
+	return fmt.Sprintln(`ADES200 - Expression in 'ericcornelissen/git-tag-annotation-action' tag input
+
+When a workflow expression is used in the tag input for 'ericcornelissen/git-tag-annotation-action'
+in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see GHSA-hgx2-4pp9-357g. To
+mitigate this, upgrade the action to a non-vulnerable version.`)
 }

--- a/explain_test.go
+++ b/explain_test.go
@@ -23,6 +23,7 @@ func TestExplainRule(t *testing.T) {
 	testCases := []string{
 		expressionInRunScriptId,
 		expressionInActionsGithubScriptId,
+		expressionInGitTagAnnotationActionTagInputId,
 	}
 
 	for _, tt := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tetafro/godot v1.4.16
 	github.com/tomarrell/wrapcheck/v2 v2.8.1
 	go.uber.org/nilaway v0.0.0-20231117175943-a267567c6fff
+	golang.org/x/mod v0.14.0
 	golang.org/x/tools v0.16.0
 	golang.org/x/vuln v1.0.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -66,7 +67,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231206192017-f3f8817b8deb // indirect
-	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/output_test.go
+++ b/output_test.go
@@ -155,7 +155,27 @@ func TestPrintViolations(t *testing.T) {
        (make sure to keep the behavior of the script the same)
 `,
 		},
-
+		{
+			name: "Workflow with violation in ericcornelissen/git-tag-annotation-action",
+			violations: func() map[string][]violation {
+				m := make(map[string][]violation)
+				m["workflow.yml"] = make([]violation, 1)
+				m["workflow.yml"][0] = violation{
+					jobId:   "4",
+					stepId:  "2",
+					problem: "${{ foo.bar }}",
+					kind:    expressionInGitTagAnnotationActionTagInput,
+				}
+				return m
+			},
+			want: `Detected 1 violation(s) in "workflow.yml":
+  job "4", step "2" has "${{ foo.bar }}" (ADES200)
+`,
+			wantSuggestions: `Detected 1 violation(s) in "workflow.yml":
+  job "4", step "2" has "${{ foo.bar }}", suggestion:
+    1. Upgrade to a non-vulnerable version, see GHSA-hgx2-4pp9-357g
+`,
+		},
 		{
 			name: "Manifest with violation in run script",
 			violations: func() map[string][]violation {
@@ -198,6 +218,26 @@ func TestPrintViolations(t *testing.T) {
     1. Set ` + "`" + `BAR: ${{ foo.bar }}` + "`" + ` in the step's ` + "`" + `env` + "`" + ` map
     2. Replace all occurrences of ` + "`" + `${{ foo.bar }}` + "`" + ` by ` + "`" + `process.env.BAR` + "`" + `
        (make sure to keep the behavior of the script the same)
+`,
+		},
+		{
+			name: "Manifest with violation in ericcornelissen/git-tag-annotation-action",
+			violations: func() map[string][]violation {
+				m := make(map[string][]violation)
+				m["action.yml"] = make([]violation, 1)
+				m["action.yml"][0] = violation{
+					stepId:  "2",
+					problem: "${{ foo.bar }}",
+					kind:    expressionInGitTagAnnotationActionTagInput,
+				}
+				return m
+			},
+			want: `Detected 1 violation(s) in "action.yml":
+  step "2" has "${{ foo.bar }}" (ADES200)
+`,
+			wantSuggestions: `Detected 1 violation(s) in "action.yml":
+  step "2" has "${{ foo.bar }}", suggestion:
+    1. Upgrade to a non-vulnerable version, see GHSA-hgx2-4pp9-357g
 `,
 		},
 	}

--- a/parse.go
+++ b/parse.go
@@ -43,6 +43,7 @@ type JobStep struct {
 // StepWith is a (simplified) representation of a job step's `with:` object.
 type StepWith struct {
 	Script string `yaml:"script"`
+	Tag    string `yaml:"tag"`
 }
 
 // ParseWorkflow parses a GitHub Actions workflow file into a Workflow struct.


### PR DESCRIPTION
Closes #95

## Summary

Expand the scope of this scanner by also looking for the use of action expressions in Action inputs that are known to be vulnerable to injection, starting with `ericcornelissen/git-tag-annotation-action` as a proof of concept.

The difference between these violations and those previously covered is that it only concerns Action inputs which shouldn't be dangerous, but are in practice because of a bug (vulnerability) in the action. Whereas using expressions in `run:` and `actions/github-script` is always dangerous.

The current implementation is limited to only the `uses:` syntax with full versions, not SHA pins or moving major version refs.