### PR TITLE
Detect use of expression in vulnerable `kceb/git-message-action` sha input

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -69,3 +69,9 @@ in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see [GH
 To avoid this, upgrade the action to a non-vulnerable version.
 
 [GHSA-hgx2-4pp9-357g]: https://github.com/ericcornelissen/git-tag-annotation-action/security/advisories/GHSA-hgx2-4pp9-357g
+
+## ADES201 - Expression in `kceb/git-message-action` sha input
+
+When a workflow expression is used in the sha input for `kceb/git-message-action` in v1.1.0 or
+earlier it may be used to execute arbitrary shell commands (no vulnerability identifier available).
+To mitigate this, upgrade the action to a non-vulnerable version.

--- a/analyze.go
+++ b/analyze.go
@@ -28,12 +28,14 @@ const (
 	expressionInRunScript violationKind = iota
 	expressionInActionsGithubScript
 	expressionInGitTagAnnotationActionTagInput
+	expressionInGitMessageActionShaInput
 )
 
 var (
 	expressionInRunScriptId                      = "ADES100"
 	expressionInActionsGithubScriptId            = "ADES101"
 	expressionInGitTagAnnotationActionTagInputId = "ADES200"
+	expressionInGitMessageActionShaInputId       = "ADES201"
 )
 
 func (kind violationKind) String() string {
@@ -45,6 +47,8 @@ func (kind violationKind) String() string {
 		s = expressionInActionsGithubScriptId
 	case expressionInGitTagAnnotationActionTagInput:
 		s = expressionInGitTagAnnotationActionTagInputId
+	case expressionInGitMessageActionShaInput:
+		s = expressionInGitMessageActionShaInputId
 	}
 
 	return s
@@ -129,6 +133,11 @@ func analyzeStep(id int, step *JobStep) []violation {
 		if isBeforeOrAtVersion(uses, "v1.0.0") {
 			kind = expressionInGitTagAnnotationActionTagInput
 			violations = analyzeString(step.With["tag"])
+		}
+	case uses.Name == "kceb/git-message-action":
+		if isBeforeOrAtVersion(uses, "v1.1.0") {
+			kind = expressionInGitMessageActionShaInput
+			violations = analyzeString(step.With["sha"])
 		}
 	}
 

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -40,6 +40,10 @@ func TestViolationKindString(t *testing.T) {
 			kind: expressionInGitTagAnnotationActionTagInput,
 			want: expressionInGitTagAnnotationActionTagInputId,
 		},
+		{
+			kind: expressionInGitMessageActionShaInput,
+			want: expressionInGitMessageActionShaInputId,
+		},
 	}
 
 	for _, tt := range testCases {
@@ -718,10 +722,86 @@ func TestAnalyzeStep(t *testing.T) {
 		},
 	}
 
+	gitMessageActionTestCases := []TestCase{
+		{
+			name: "git-message-action, vulnerable version without vulnerable input",
+			step: JobStep{
+				Name: "Vulnerable",
+				Uses: "kceb/git-message-action@v1.1.0",
+				With: map[string]string{},
+			},
+			want: []violation{},
+		},
+		{
+			name: "git-message-action, vulnerable version with vulnerable input",
+			step: JobStep{
+				Name: "Vulnerable",
+				Uses: "kceb/git-message-action@v1.1.0",
+				With: map[string]string{
+					"sha": "${{ inputs.sha }}",
+				},
+			},
+			want: []violation{
+				{
+					stepId:  "Vulnerable",
+					problem: "${{ inputs.sha }}",
+					kind:    expressionInGitMessageActionShaInput,
+				},
+			},
+		},
+		{
+			name: "git-tag-annotation-action, old version without vulnerable input",
+			step: JobStep{
+				Name: "Old",
+				Uses: "kceb/git-message-action@v1.0.0",
+				With: map[string]string{},
+			},
+			want: []violation{},
+		},
+		{
+			name: "git-tag-annotation-action, old version with vulnerable input",
+			step: JobStep{
+				Name: "Old",
+				Uses: "kceb/git-message-action@v1.0.0",
+				With: map[string]string{
+					"sha": "${{ inputs.sha }}",
+				},
+			},
+			want: []violation{
+				{
+					stepId:  "Old",
+					problem: "${{ inputs.sha }}",
+					kind:    expressionInGitMessageActionShaInput,
+				},
+			},
+		},
+		{
+			name: "git-message-action, fixed version without vulnerable input",
+			step: JobStep{
+				Name: "Fixed",
+				Uses: "kceb/git-message-action@v1.2.0",
+				With: map[string]string{},
+			},
+			want: []violation{},
+		},
+		{
+			name: "git-message-action, fixed version with vulnerable input",
+			step: JobStep{
+				Name: "Fixed",
+				Uses: "kceb/git-message-action@v1.2.0",
+				With: map[string]string{
+					"sha": "${{ inputs.sha }}",
+				},
+			},
+			want: []violation{},
+		},
+	}
+
 	var allTestCases []TestCase
 	allTestCases = append(allTestCases, runTestCases...)
 	allTestCases = append(allTestCases, actionsGitHubScriptCases...)
 	allTestCases = append(allTestCases, actionTestCases...)
+	allTestCases = append(allTestCases, gitMessageActionTestCases...)
 
 	for _, tt := range allTestCases {
 		tt := tt

--- a/explain.go
+++ b/explain.go
@@ -25,6 +25,8 @@ func explain(violationId string) (explanation string, err error) {
 		explanation = explainAdes101()
 	case expressionInGitTagAnnotationActionTagInputId:
 		explanation = explainAdes200()
+	case expressionInGitMessageActionShaInputId:
+		explanation = explainAdes201()
 	default:
 		err = fmt.Errorf("unknown rule %q", violationId)
 	}
@@ -91,4 +93,12 @@ func explainAdes200() string {
 When a workflow expression is used in the tag input for 'ericcornelissen/git-tag-annotation-action'
 in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see GHSA-hgx2-4pp9-357g. To
 mitigate this, upgrade the action to a non-vulnerable version.`)
+}
+
+func explainAdes201() string {
+	return fmt.Sprintln(`ADES201 - Expression in 'kceb/git-message-action' sha input
+
+When a workflow expression is used in the sha input for 'kceb/git-message-action' in v1.1.0 or
+earlier it may be used to execute arbitrary shell commands (no vulnerability identifier available).
+To mitigate this, upgrade the action to a non-vulnerable version.`)
 }

--- a/explain_test.go
+++ b/explain_test.go
@@ -24,6 +24,7 @@ func TestExplainRule(t *testing.T) {
 		expressionInRunScriptId,
 		expressionInActionsGithubScriptId,
 		expressionInGitTagAnnotationActionTagInputId,
+		expressionInGitMessageActionShaInputId,
 	}
 
 	for _, tt := range testCases {

--- a/output.go
+++ b/output.go
@@ -101,6 +101,8 @@ func printViolation(v *violation, suggestions bool) string {
 			sb.WriteString("       (make sure to keep the behavior of the script the same)")
 		case expressionInGitTagAnnotationActionTagInput:
 			sb.WriteString("    1. Upgrade to a non-vulnerable version, see GHSA-hgx2-4pp9-357g")
+		case expressionInGitMessageActionShaInput:
+			sb.WriteString("    1. Upgrade to a non-vulnerable version, see v1.2.0 release notes")
 		}
 	} else {
 		sb.WriteString(fmt.Sprintf(" (%s)", v.kind))

--- a/output_test.go
+++ b/output_test.go
@@ -177,6 +177,27 @@ func TestPrintViolations(t *testing.T) {
 `,
 		},
 		{
+			name: "Workflow with violation in kceb/git-message-action",
+			violations: func() map[string][]violation {
+				m := make(map[string][]violation)
+				m["workflow.yml"] = make([]violation, 1)
+				m["workflow.yml"][0] = violation{
+					jobId:   "4",
+					stepId:  "2",
+					problem: "${{ foo.bar }}",
+					kind:    expressionInGitMessageActionShaInput,
+				}
+				return m
+			},
+			want: `Detected 1 violation(s) in "workflow.yml":
+  job "4", step "2" has "${{ foo.bar }}" (ADES201)
+`,
+			wantSuggestions: `Detected 1 violation(s) in "workflow.yml":
+  job "4", step "2" has "${{ foo.bar }}", suggestion:
+    1. Upgrade to a non-vulnerable version, see v1.2.0 release notes
+`,
+		},
+		{
 			name: "Manifest with violation in run script",
 			violations: func() map[string][]violation {
 				m := make(map[string][]violation)
@@ -238,6 +259,26 @@ func TestPrintViolations(t *testing.T) {
 			wantSuggestions: `Detected 1 violation(s) in "action.yml":
   step "2" has "${{ foo.bar }}", suggestion:
     1. Upgrade to a non-vulnerable version, see GHSA-hgx2-4pp9-357g
+`,
+		},
+		{
+			name: "Manifest with violation in kceb/git-message-action",
+			violations: func() map[string][]violation {
+				m := make(map[string][]violation)
+				m["action.yml"] = make([]violation, 1)
+				m["action.yml"][0] = violation{
+					stepId:  "2",
+					problem: "${{ foo.bar }}",
+					kind:    expressionInGitMessageActionShaInput,
+				}
+				return m
+			},
+			want: `Detected 1 violation(s) in "action.yml":
+  step "2" has "${{ foo.bar }}" (ADES201)
+`,
+			wantSuggestions: `Detected 1 violation(s) in "action.yml":
+  step "2" has "${{ foo.bar }}", suggestion:
+    1. Upgrade to a non-vulnerable version, see v1.2.0 release notes
 `,
 		},
 	}


### PR DESCRIPTION
Relates to #95, #106

## Summary

Expand the scanner with coverage of the [kceb/git-message-action](https://github.com/kceb/git-message-action) action's sha input, which prior to [v1.2.0](https://github.com/kceb/git-message-action/releases/tag/v1.2.0) was vulnerable to shell injection.