### PR TITLE
Correct license text for tools.go

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -9,9 +9,6 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
Relates to #83

## Summary

Correct the license text for the `MIT-0` licensed used on `tools.go`. The inclusion of the permission notice is precisely what isn't necessary with the no-attribution variant of MIT.