### PR TITLE
Change process from stdin flag from `-stdin` to `-`

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,11 +49,6 @@ var (
 		false,
 		"Show legal information and exit",
 	)
-	flagStdin = flag.Bool(
-		"stdin",
-		false,
-		"Read workflow or manifest from stdin",
-	)
 	flagSuggestions = flag.Bool(
 		"suggestions",
 		false,
@@ -95,25 +90,26 @@ func run() int {
 		}
 	}
 
-	var ok bool
-	var targets []string
-	var report map[string]map[string][]violation
+	targets := flag.Args()
+	if len(targets) == 0 {
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Printf("Unexpected error getting working directory: %s", err)
+			return exitError
+		}
 
-	if *flagStdin {
+		targets = []string{wd}
+	}
+
+	var (
+		ok     bool
+		report map[string]map[string][]violation
+	)
+
+	if targets[0] == "-" {
 		targets = []string{"stdin"}
 		report, ok = runOnStdin()
 	} else {
-		targets = flag.Args()
-		if len(targets) == 0 {
-			wd, err := os.Getwd()
-			if err != nil {
-				fmt.Printf("Unexpected error getting working directory: %s", err)
-				return exitError
-			}
-
-			targets = []string{wd}
-		}
-
 		report, ok = runOnTargets(targets)
 	}
 
@@ -327,9 +323,9 @@ Flags:
   -help              Show this help message and exit.
   -json              Output results in JSON format.
   -legal             Show legal information and exit.
-  -stdin             Read workflow or manifest from stdin.
   -suggestions       Show suggested fixes inline.
   -version           Show the program version and exit.
+  -                  Read workflow or manifest from stdin.
 
 Exit Codes:
 

--- a/test/stdin.txtar
+++ b/test/stdin.txtar
@@ -1,28 +1,28 @@
 # Safe manifest
 stdin safe/action.yml
-exec ades -stdin
+exec ades -
 ! stdout .
 ! stderr .
 
 # Safe workflow
 stdin .github/workflows/safe.yml
-exec ades -stdin
+exec ades -
 ! stdout .
 ! stderr .
 
 # Unsafe manifest
 stdin unsafe/action.yml
-! exec ades -stdin
+! exec ades -
 ! stderr .
 
 # Unsafe workflow
 stdin .github/workflows/unsafe.yml
-! exec ades -stdin
+! exec ades -
 ! stderr .
 
 # Not yaml
 stdin not-yaml.txt
-! exec ades -stdin
+! exec ades -
 stdout 'Could not parse input, is it YAML?'
 ! stderr .
 

--- a/test/stdout.txtar
+++ b/test/stdout.txtar
@@ -30,7 +30,7 @@ cmp stdout $WORK/snapshots/json-multiple-stdout.txt
 
 # Stdin
 stdin project/.github/workflows/workflow.yml
-! exec ades -stdin
+! exec ades -
 cmp stdout $WORK/snapshots/stdin-stdout.txt
 ! stderr .
 


### PR DESCRIPTION
Relates to #80

## Summary

Replace the `-stdin` flag by `-` for reading a file from stdin. This is inspired by the same strategy used by some other CLI tools (whereas I've never seen an `-stdin` flag for this purpose).