### PR TITLE
Align `-help` program description with README.md

### DIFF
--- a/main.go
+++ b/main.go
@@ -315,7 +315,7 @@ conditions; see the GPL v3.0 for details.`)
 }
 
 func usage() {
-	fmt.Println(`find problematic use of template variables in GitHub Action workflows
+	fmt.Println(`find dangerous uses of expressions in GitHub Action workflows
 
 Usage:
 

--- a/test/flags-info.txtar
+++ b/test/flags-info.txtar
@@ -1,6 +1,6 @@
 # Help
 exec ades -help
-stdout 'find problematic use of template variables in GitHub Action workflows\n'
+stdout 'find dangerous uses of expressions in GitHub Action workflows\n'
 ! stderr .
 
 # Legal


### PR DESCRIPTION
## Summary

Update the first line of the `-help` text to align wording with the README.md and overall project.