### PR TITLE
Add explicit license to the `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,22 @@
+# MIT No Attribution
+#
+# Copyright (c) 2024 Eric Cornelissen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 CONTAINER_ENGINE?=docker
 CONTAINER_TAG?=latest
 


### PR DESCRIPTION
Relates to #65

## Summary

Add an explicit license to the `Makefile` (Following in the footsteps of `Containerfile.dev` and `tools.go`).

Earlier I wasn't sure whether I would categorize `Makefile` as a configuration file or not, since then I've come to the conclusion that it's closer to say a `Containerfile` than a (pure) configuration file. Hence this adds an explicit license.