### PR TITLE
Use `ireturn` for idiomatic Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ vet: ## Vet the source code
 	@go run github.com/alexkohler/nakedret/v2/cmd/nakedret -l 0 .
 	@go run github.com/alexkohler/prealloc -set_exit_status .
 	@go run github.com/alexkohler/unimport .
+	@go run github.com/butuzov/ireturn/cmd/ireturn .
 	@go run github.com/catenacyber/perfsprint .
 	@go run github.com/dkorunic/betteralign/cmd/betteralign .
 	@go run github.com/go-critic/go-critic/cmd/gocritic check .

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alexkohler/nakedret/v2 v2.0.1
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/alexkohler/unimport v0.0.0-20171106223308-e6f2b2e2d406
+	github.com/butuzov/ireturn v0.2.2
 	github.com/catenacyber/perfsprint v0.5.0
 	github.com/dkorunic/betteralign v0.3.3
 	github.com/go-critic/go-critic v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/butuzov/ireturn v0.2.2 h1:jWI36dxXwVrI+RnXDwux2IZOewpmfv930OuIRfaBUJ0=
+github.com/butuzov/ireturn v0.2.2/go.mod h1:RfGHUvvAuFFxoHKf4Z8Yxuh6OjlCw1KvR2zM1NFHeBk=
 github.com/catenacyber/perfsprint v0.5.0 h1:FNBJRKm2Lar44u1s7DUfpbiY4iN2LmnK6THY3d5rL40=
 github.com/catenacyber/perfsprint v0.5.0/go.mod h1:/wclWYompEyjUD2FuIIDVKNkqz7IgBIWXIH3V0Zol50=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tools.go
+++ b/tools.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/alexkohler/nakedret/v2/cmd/nakedret"
 	_ "github.com/alexkohler/prealloc"
 	_ "github.com/alexkohler/unimport"
+	_ "github.com/butuzov/ireturn/cmd/ireturn"
 	_ "github.com/catenacyber/perfsprint"
 	_ "github.com/dkorunic/betteralign/cmd/betteralign"
 	_ "github.com/go-critic/go-critic/cmd/gocritic"


### PR DESCRIPTION
## Summary

Extend list of tools used for vetting to include a tool called [ireturn](https://github.com/butuzov/ireturn), to enforce the principle of accepting interfaces and returning concrete types.This code base currently has no violations w.r.t. this tool so no further changes are included.