### PR TITLE
Explain how to use Go to run ades

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ You can also use the containerized version of the CLI, for example using Docker:
 docker run --rm --volume $PWD:/src docker.io/ericornelissen/ades .
 ```
 
+Or you can use Go to build from source and run the CLI directly, for example using `go run`:
+
+```shell
+go run github.com/ericcornelissen/ades@latest .
+```
+
 ### Features
 
 - Scan workflow files and action manifests.


### PR DESCRIPTION
Relates to #81

## Summary

Update the "Usage" section of the documentation to include an example of how to use Go to (build from source and) run `ades` from the CLI.