### PR TITLE
Add output when no dangerous expressions were detected

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,6 +113,10 @@ func run() int {
 		report, ok = runOnTargets(targets)
 	}
 
+	if !ok {
+		return exitError
+	}
+
 	if *flagJson {
 		fmt.Println(printJson(report))
 	} else {
@@ -127,10 +131,6 @@ func run() int {
 			violations := report[target]
 			fmt.Print(printViolations(violations, *flagSuggestions))
 		}
-	}
-
-	if !ok {
-		return exitError
 	}
 
 	for _, targetViolations := range report {

--- a/output.go
+++ b/output.go
@@ -59,9 +59,12 @@ func printJson(rawViolations map[string]map[string][]violation) string {
 }
 
 func printViolations(violations map[string][]violation, suggestions bool) string {
+	clean := true
+
 	var sb strings.Builder
 	for file, fileViolations := range violations {
 		if cnt := len(fileViolations); cnt > 0 {
+			clean = false
 			sb.WriteString(fmt.Sprintf("Detected %d violation(s) in %q:", cnt, file))
 			sb.WriteRune('\n')
 			for _, violation := range fileViolations {
@@ -72,7 +75,11 @@ func printViolations(violations map[string][]violation, suggestions bool) string
 		}
 	}
 
-	return sb.String()
+	if clean {
+		return "Ok\n"
+	} else {
+		return sb.String()
+	}
 }
 
 func printViolation(v *violation, suggestions bool) string {

--- a/output_test.go
+++ b/output_test.go
@@ -97,8 +97,10 @@ func TestPrintViolations(t *testing.T) {
 			violations: func() map[string][]violation {
 				return make(map[string][]violation)
 			},
-			want:            ``,
-			wantSuggestions: ``,
+			want: `Ok
+`,
+			wantSuggestions: `Ok
+`,
 		},
 		{
 			name: "File without violations",
@@ -107,8 +109,10 @@ func TestPrintViolations(t *testing.T) {
 				m["workflow.yml"] = make([]violation, 0)
 				return m
 			},
-			want:            ``,
-			wantSuggestions: ``,
+			want: `Ok
+`,
+			wantSuggestions: `Ok
+`,
 		},
 		{
 			name: "Workflow with a violation",

--- a/test/args.txtar
+++ b/test/args.txtar
@@ -2,38 +2,43 @@
 mkdir empty
 
 exec ades 'empty'
-! stdout .
+stdout 'Ok'
 ! stderr .
 
 # Safe project
 exec ades 'safe'
-! stdout .
+stdout 'Ok'
 ! stderr .
 
 # Unsafe manifest (.yml)
 ! exec ades 'manifests/action.yml'
 stdout 'manifests/action.yml'
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe manifest (.yaml)
 ! exec ades 'manifests/action.yaml'
 stdout 'manifests/action.yaml'
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe workflow (.yml)
 ! exec ades 'workflows/.github/workflows/unsafe.yml'
 stdout 'workflows/.github/workflows/unsafe.yml'
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe workflow (.yaml)
 ! exec ades 'workflows/.github/workflows/unsafe.yaml'
 stdout 'workflows/.github/workflows/unsafe.yaml'
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe project
 ! exec ades 'workflows'
 stdout '.github/workflows/unsafe.yml'
 stdout '.github/workflows/unsafe.yaml'
+! stdout 'Ok'
 ! stderr .
 
 # Multiple targets

--- a/test/cwd.txtar
+++ b/test/cwd.txtar
@@ -3,14 +3,14 @@ mkdir empty
 cd empty
 
 exec ades
-! stdout .
+stdout 'Ok'
 ! stderr .
 
 # Safe project
 cd ../safe
 
 exec ades
-! stdout .
+stdout 'Ok'
 ! stderr .
 
 # Unsafe manifest (.yml)
@@ -18,6 +18,7 @@ cd ../action-yml
 
 ! exec ades
 stdout 'action.yml'
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe manifest (.yaml)
@@ -25,6 +26,7 @@ cd ../action-yaml
 
 ! exec ades
 stdout 'action.yaml'
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe workflows
@@ -33,6 +35,7 @@ cd ../workflows
 ! exec ades
 stdout '.github/workflows/unsafe.yml'
 stdout '.github/workflows/unsafe.yaml'
+! stdout 'Ok'
 ! stderr .
 
 

--- a/test/stdin.txtar
+++ b/test/stdin.txtar
@@ -1,29 +1,32 @@
 # Safe manifest
 stdin safe/action.yml
 exec ades -
-! stdout .
+stdout 'Ok'
 ! stderr .
 
 # Safe workflow
 stdin .github/workflows/safe.yml
 exec ades -
-! stdout .
+stdout 'Ok'
 ! stderr .
 
 # Unsafe manifest
 stdin unsafe/action.yml
 ! exec ades -
+! stdout 'Ok'
 ! stderr .
 
 # Unsafe workflow
 stdin .github/workflows/unsafe.yml
 ! exec ades -
+! stdout 'Ok'
 ! stderr .
 
 # Not yaml
 stdin not-yaml.txt
 ! exec ades -
 stdout 'Could not parse input, is it YAML?'
+! stdout 'Ok'
 ! stderr .
 
 


### PR DESCRIPTION
## Summary

Update the output of the CLI to say something instead of nothing to make it clearer that there were no problems found. It applies to both single- and multi-target usage, but is primarily useful for single-target usage where there was previously no output.