### PR TITLE
Audit only when necessary

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,11 @@
 name: Audit
 on:
-  pull_request: ~
+  pull_request:
+    paths:
+    - .github/workflows/audit.yml
+    - '*.go'
+    - go.mod
+    - go.sum
   push:
     branches:
     - main


### PR DESCRIPTION
## Summary

Update the `audit.yml` workflow to only trigger for Pull Requests when there is a chance for a new finding as a result of the change. The motivation for this is to reduce unexpected CI failures. For example when only a text/MarkDown file is changed the result of this workflow is not interesting.