### PR TITLE
Extract command and make library importable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@
 !capabilities.json
 
 # Source
+!cmd/
+cmd/**
+!cmd/ades/
+cmd/ades/**
+!cmd/ades/*.go
 !Containerfile
 !Containerfile.dev
 !Makefile

--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,8 @@
 FROM docker.io/golang:1.22.0 AS build
 
 WORKDIR /src
+
+COPY cmd/ ./cmd/
 COPY Makefile go.mod go.sum *.go ./
 
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ audit-capabilities: ## Audit for capabilities
 
 audit-vulnerabilities: ## Audit for vulnerabilities
 	@echo 'Checking vulnerabilities...'
-	@go run golang.org/x/vuln/cmd/govulncheck .
+	@go run golang.org/x/vuln/cmd/govulncheck ./...
 
 update-capabilities:
 	@echo 'Updating capabilities...'
@@ -50,14 +50,14 @@ update-capabilities:
 .PHONY: build
 build: ## Build the ades binary for the current platform
 	@echo 'Building...'
-	@go build .
+	@go build ./cmd/ades
 
 .PHONY: clean
 clean: ## Reset the project to a clean state
 	@echo 'Cleaning...'
 	@git clean -fx \
 		_compiled/ \
-		ades \
+		ades* \
 		cover.*
 
 .PHONY: compliance
@@ -65,7 +65,7 @@ compliance: ## Check license compliance
 	@echo 'Checking license compliance...'
 	@go run github.com/google/go-licenses check \
 		--allowed_licenses BSD-3-Clause,GPL-3.0,MIT \
-		.
+		./...
 
 .PHONY: container
 container: ## Build the ades container for the current platform
@@ -77,7 +77,7 @@ container: ## Build the ades container for the current platform
 .PHONY: coverage
 coverage: ## Run all tests and generate a coverage report
 	@echo 'Testing...'
-	@go test -coverprofile cover.out .
+	@go test -coverprofile cover.out ./...
 	@echo 'Generating coverage report...'
 	@go tool cover -html cover.out -o cover.html
 
@@ -107,6 +107,7 @@ fmt: ## Format the source code
 fmt-check: ## Check the source code formatting
 	@echo 'Checking formatting...'
 	@test -z "$$(gofmt -l .)"
+	@test -z "$$(gofmt -l -r 'interface{} -> any' .)"
 	@test -z "$$(go run golang.org/x/tools/cmd/goimports -l .)"
 
 .PHONY: release release-compile
@@ -147,55 +148,55 @@ release-compile:
 	@mkdir _compiled/
 
 	@echo 'Compiling for darwin/amd64...'
-	@env GOOS=darwin GOARCH=amd64 go build -o 'ades'
+	@env GOOS=darwin GOARCH=amd64 go build -o 'ades' ./cmd/ades
 	@tar -czf 'ades_darwin_amd64.tar.gz' 'ades'
 	@mv 'ades_darwin_amd64.tar.gz' '_compiled/'
 
 	@echo 'Compiling for darwin/arm64...'
-	@env GOOS=darwin GOARCH=arm64 go build -o 'ades'
+	@env GOOS=darwin GOARCH=arm64 go build -o 'ades' ./cmd/ades
 	@tar -czf 'ades_darwin_arm64.tar.gz' 'ades'
 	@mv 'ades_darwin_arm64.tar.gz' '_compiled/'
 
 	@echo 'Compiling for linux/386...'
-	@env GOOS=linux GOARCH=386 go build -o 'ades'
+	@env GOOS=linux GOARCH=386 go build -o 'ades' ./cmd/ades
 	@tar -czf 'ades_linux_386.tar.gz' 'ades'
 	@mv 'ades_linux_386.tar.gz' '_compiled/'
 
 	@echo 'Compiling for linux/amd64...'
-	@env GOOS=linux GOARCH=amd64 go build -o 'ades'
+	@env GOOS=linux GOARCH=amd64 go build -o 'ades' ./cmd/ades
 	@tar -czf 'ades_linux_amd64.tar.gz' 'ades'
 	@mv 'ades_linux_amd64.tar.gz' '_compiled/'
 
 	@echo 'Compiling for linux/arm...'
-	@env GOOS=linux GOARCH=arm go build -o 'ades'
+	@env GOOS=linux GOARCH=arm go build -o 'ades' ./cmd/ades
 	@tar -czf 'ades_linux_arm.tar.gz' 'ades'
 	@mv 'ades_linux_arm.tar.gz' '_compiled/'
 
 	@echo 'Compiling for linux/arm64...'
-	@env GOOS=linux GOARCH=arm64 go build -o 'ades'
+	@env GOOS=linux GOARCH=arm64 go build -o 'ades' ./cmd/ades
 	@tar -czf 'ades_linux_arm64.tar.gz' 'ades'
 	@mv 'ades_linux_arm64.tar.gz' '_compiled/'
 
 	@echo 'Compiling for windows/386...'
-	@env GOOS=windows GOARCH=386 go build -o 'ades'
+	@env GOOS=windows GOARCH=386 go build -o 'ades' ./cmd/ades
 	@mv 'ades' 'ades.exe'
 	@zip -9q 'ades_windows_386.zip' 'ades.exe'
 	@mv 'ades_windows_386.zip' '_compiled/'
 
 	@echo 'Compiling for windows/amd64...'
-	@env GOOS=windows GOARCH=amd64 go build -o 'ades'
+	@env GOOS=windows GOARCH=amd64 go build -o 'ades' ./cmd/ades
 	@mv 'ades' 'ades.exe'
 	@zip -9q 'ades_windows_amd64.zip' 'ades.exe'
 	@mv 'ades_windows_amd64.zip' '_compiled/'
 
 	@echo 'Compiling for windows/arm...'
-	@env GOOS=windows GOARCH=arm go build -o 'ades'
+	@env GOOS=windows GOARCH=arm go build -o 'ades' ./cmd/ades
 	@mv 'ades' 'ades.exe'
 	@zip -9q 'ades_windows_arm.zip' 'ades.exe'
 	@mv 'ades_windows_arm.zip' '_compiled/'
 
 	@echo 'Compiling for windows/arm64...'
-	@env GOOS=windows GOARCH=arm64 go build -o 'ades'
+	@env GOOS=windows GOARCH=arm64 go build -o 'ades' ./cmd/ades
 	@mv 'ades' 'ades.exe'
 	@zip -9q 'ades_windows_arm64.zip' 'ades.exe'
 	@mv 'ades_windows_arm64.zip' '_compiled/'
@@ -205,12 +206,12 @@ release-compile:
 
 .PHONY: run
 run: ## Run the project on itself
-	@go run .
+	@go run ./cmd/ades
 
 .PHONY: test
 test: ## Run all tests
 	@echo 'Testing...'
-	@go test .
+	@go test ./...
 
 .PHONY: test-mutation
 test-mutation: ## Run mutation tests
@@ -220,37 +221,38 @@ test-mutation: ## Run mutation tests
 .PHONY: test-randomized
 test-randomized: ## Run tests in a random order
 	@echo 'Testing (random order)...'
-	@go test -shuffle=on .
+	@go test -shuffle=on ./...
 
 .PHONY: vet
 vet: ## Vet the source code
 	@echo 'Vetting...'
-	@go vet .
-	@go run 4d63.com/gochecknoinits .
-	@go run github.com/alexkohler/dogsled/cmd/dogsled -set_exit_status .
-	@go run github.com/alexkohler/nakedret/v2/cmd/nakedret -l 0 .
-	@go run github.com/alexkohler/prealloc -set_exit_status .
-	@go run github.com/alexkohler/unimport .
-	@go run github.com/butuzov/ireturn/cmd/ireturn .
-	@go run github.com/catenacyber/perfsprint .
-	@go run github.com/dkorunic/betteralign/cmd/betteralign .
-	@go run github.com/go-critic/go-critic/cmd/gocritic check .
-	@go run github.com/gordonklaus/ineffassign .
-	@go run github.com/jgautheron/goconst/cmd/goconst -set-exit-status .
-	@go run github.com/kisielk/errcheck .
-	@go run github.com/kunwardeep/paralleltest -i -ignoreloopVar .
-	@go run github.com/mdempsky/unconvert .
-	@go run github.com/nishanths/exhaustive/cmd/exhaustive .
-	@go run github.com/polyfloyd/go-errorlint .
+	@go vet ./...
+	@go run 4d63.com/gochecknoinits ./...
+	@go run github.com/alexkohler/dogsled/cmd/dogsled -set_exit_status ./...
+	@go run github.com/alexkohler/nakedret/v2/cmd/nakedret -l 0 ./...
+	@go run github.com/alexkohler/prealloc -set_exit_status ./...
+	@go run github.com/alexkohler/unimport ./...
+	@go run github.com/butuzov/ireturn/cmd/ireturn ./...
+	@go run github.com/catenacyber/perfsprint ./...
+	@go run github.com/dkorunic/betteralign/cmd/betteralign ./...
+	@go run github.com/go-critic/go-critic/cmd/gocritic check ./...
+	@go run github.com/gordonklaus/ineffassign ./...
+	@go run github.com/jgautheron/goconst/cmd/goconst -set-exit-status ./...
+	@go run github.com/kisielk/errcheck ./...
+	@go run github.com/kunwardeep/paralleltest -i -ignoreloopVar ./...
+	@go run github.com/mdempsky/unconvert ./...
+	@go run github.com/nishanths/exhaustive/cmd/exhaustive ./...
+	@go run github.com/polyfloyd/go-errorlint ./...
 	@go run github.com/remyoudompheng/go-misc/deadcode .
+	@go run github.com/remyoudompheng/go-misc/deadcode ./cmd/ades
 	@go run github.com/rhysd/actionlint/cmd/actionlint
 	@go run github.com/tetafro/godot/cmd/godot .
-	@go run github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck .
-	@go run github.com/ultraware/whitespace/cmd/whitespace .
-	@go run go.uber.org/nilaway/cmd/nilaway .
-	@go run golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow .
-	@go run honnef.co/go/tools/cmd/staticcheck .
-	@go run mvdan.cc/unparam .
+	@go run github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck ./...
+	@go run github.com/ultraware/whitespace/cmd/whitespace ./...
+	@go run go.uber.org/nilaway/cmd/nilaway ./...
+	@go run golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow ./...
+	@go run honnef.co/go/tools/cmd/staticcheck ./...
+	@go run mvdan.cc/unparam ./...
 
 .PHONY: verify
 verify: build compliance fmt-check test run vet ## Verify project is in a good state

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run --rm --volume $PWD:/src docker.io/ericornelissen/ades .
 Or you can use Go to build from source and run the CLI directly, for example using `go run`:
 
 ```shell
-go run github.com/ericcornelissen/ades@latest .
+go run github.com/ericcornelissen/ades/cmd/ades@latest .
 ```
 
 ### Features

--- a/analyze.go
+++ b/analyze.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package ades
 
 import (
 	"fmt"

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package ades
 
 import (
 	"testing"
@@ -474,6 +474,34 @@ func TestAnalyzeStep(t *testing.T) {
 			},
 			wantCount:  2,
 			wantStepId: "Greet person today",
+		},
+		{
+			name: "Uses step with unknown action",
+			id:   1,
+			step: JobStep{
+				Uses: "this/is-not@a-real-action",
+			},
+			wantCount: 0,
+		},
+		{
+			name: "Uses step with known action, no violations",
+			id:   1,
+			step: JobStep{
+				Uses: "actions/github-script@v6",
+			},
+			wantCount: 0,
+		},
+		{
+			name: "Uses step with known action, no violations",
+			id:   1,
+			step: JobStep{
+				Uses: "actions/github-script@v6",
+				With: map[string]string{
+					"script": "console.log('Hello ${{ inputs.name }}')",
+				},
+			},
+			wantCount:  1,
+			wantStepId: "#1",
 		},
 	}
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -1,639 +1,51 @@
 {
 	"capabilityInfo": [
 		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.main github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget os.Stat",
+			"packageName": "ades",
+			"capability": "CAPABILITY_UNSAFE_POINTER",
+			"depPath": "github.com/ericcornelissen/ades.Suggestion github.com/ericcornelissen/ades.suggestJavaScriptEnv github.com/ericcornelissen/ades.suggestUseEnv (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
 			"path": [
 				{
-					"name": "github.com/ericcornelissen/ades.main"
+					"name": "github.com/ericcornelissen/ades.Suggestion"
 				},
 				{
-					"name": "github.com/ericcornelissen/ades.run",
+					"name": "github.com/ericcornelissen/ades.suggestJavaScriptEnv",
 					"site": {
-						"filename": "main.go",
-						"line": "65",
+						"filename": "rules.go",
+						"line": "318",
+						"column": "21"
+					}
+				},
+				{
+					"name": "github.com/ericcornelissen/ades.suggestUseEnv",
+					"site": {
+						"filename": "rules.go",
+						"line": "340",
+						"column": "22"
+					}
+				},
+				{
+					"name": "(*strings.Builder).WriteRune",
+					"site": {
+						"filename": "rules.go",
+						"line": "358",
+						"column": "14"
+					}
+				},
+				{
+					"name": "(*strings.Builder).copyCheck",
+					"site": {
+						"filename": "builder.go",
+						"line": "106",
 						"column": "13"
 					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets",
-					"site": {
-						"filename": "main.go",
-						"line": "113",
-						"column": "28"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "os.Stat",
-					"site": {
-						"filename": "main.go",
-						"line": "194",
-						"column": "22"
-					}
 				}
 			],
 			"packageDir": "github.com/ericcornelissen/ades",
 			"capabilityType": "CAPABILITY_TYPE_DIRECT"
 		},
 		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget os.Stat",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.run"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets",
-					"site": {
-						"filename": "main.go",
-						"line": "113",
-						"column": "28"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "os.Stat",
-					"site": {
-						"filename": "main.go",
-						"line": "194",
-						"column": "22"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.runOnFile os.ReadFile",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile"
-				},
-				{
-					"name": "os.ReadFile",
-					"site": {
-						"filename": "main.go",
-						"line": "273",
-						"column": "26"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.runOnRepository os.ReadDir",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository"
-				},
-				{
-					"name": "os.ReadDir",
-					"site": {
-						"filename": "main.go",
-						"line": "234",
-						"column": "30"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.runOnStdin io.ReadAll (*os.File).Read",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnStdin"
-				},
-				{
-					"name": "io.ReadAll",
-					"site": {
-						"filename": "main.go",
-						"line": "148",
-						"column": "25"
-					}
-				},
-				{
-					"name": "(*os.File).Read",
-					"site": {
-						"filename": "io.go",
-						"line": "712",
-						"column": "19"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.runOnTarget os.Stat",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget"
-				},
-				{
-					"name": "os.Stat",
-					"site": {
-						"filename": "main.go",
-						"line": "194",
-						"column": "22"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_FILES",
-			"depPath": "github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget os.Stat",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "os.Stat",
-					"site": {
-						"filename": "main.go",
-						"line": "194",
-						"column": "22"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_READ_SYSTEM_STATE",
-			"depPath": "github.com/ericcornelissen/ades.main github.com/ericcornelissen/ades.run os.Getwd",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.main"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.run",
-					"site": {
-						"filename": "main.go",
-						"line": "65",
-						"column": "13"
-					}
-				},
-				{
-					"name": "os.Getwd",
-					"site": {
-						"filename": "main.go",
-						"line": "95",
-						"column": "22"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_READ_SYSTEM_STATE",
-			"depPath": "github.com/ericcornelissen/ades.run os.Getwd",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.run"
-				},
-				{
-					"name": "os.Getwd",
-					"site": {
-						"filename": "main.go",
-						"line": "95",
-						"column": "22"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_READ_SYSTEM_STATE",
-			"depPath": "github.com/ericcornelissen/ades.runOnFile path/filepath.Abs path/filepath.abs path/filepath.unixAbs os.Getwd",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile"
-				},
-				{
-					"name": "path/filepath.Abs",
-					"site": {
-						"filename": "main.go",
-						"line": "268",
-						"column": "35"
-					}
-				},
-				{
-					"name": "path/filepath.abs",
-					"site": {
-						"filename": "path.go",
-						"line": "295",
-						"column": "12"
-					}
-				},
-				{
-					"name": "path/filepath.unixAbs",
-					"site": {
-						"filename": "path_unix.go",
-						"line": "42",
-						"column": "16"
-					}
-				},
-				{
-					"name": "os.Getwd",
-					"site": {
-						"filename": "path.go",
-						"line": "302",
-						"column": "21"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_READ_SYSTEM_STATE",
-			"depPath": "github.com/ericcornelissen/ades.runOnRepository github.com/ericcornelissen/ades.runOnFile path/filepath.Abs path/filepath.abs path/filepath.unixAbs os.Getwd",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile",
-					"site": {
-						"filename": "main.go",
-						"line": "221",
-						"column": "37"
-					}
-				},
-				{
-					"name": "path/filepath.Abs",
-					"site": {
-						"filename": "main.go",
-						"line": "268",
-						"column": "35"
-					}
-				},
-				{
-					"name": "path/filepath.abs",
-					"site": {
-						"filename": "path.go",
-						"line": "295",
-						"column": "12"
-					}
-				},
-				{
-					"name": "path/filepath.unixAbs",
-					"site": {
-						"filename": "path_unix.go",
-						"line": "42",
-						"column": "16"
-					}
-				},
-				{
-					"name": "os.Getwd",
-					"site": {
-						"filename": "path.go",
-						"line": "302",
-						"column": "21"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_READ_SYSTEM_STATE",
-			"depPath": "github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnFile path/filepath.Abs path/filepath.abs path/filepath.unixAbs os.Getwd",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile",
-					"site": {
-						"filename": "main.go",
-						"line": "202",
-						"column": "35"
-					}
-				},
-				{
-					"name": "path/filepath.Abs",
-					"site": {
-						"filename": "main.go",
-						"line": "268",
-						"column": "35"
-					}
-				},
-				{
-					"name": "path/filepath.abs",
-					"site": {
-						"filename": "path.go",
-						"line": "295",
-						"column": "12"
-					}
-				},
-				{
-					"name": "path/filepath.unixAbs",
-					"site": {
-						"filename": "path_unix.go",
-						"line": "42",
-						"column": "16"
-					}
-				},
-				{
-					"name": "os.Getwd",
-					"site": {
-						"filename": "path.go",
-						"line": "302",
-						"column": "21"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_READ_SYSTEM_STATE",
-			"depPath": "github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnFile path/filepath.Abs path/filepath.abs path/filepath.unixAbs os.Getwd",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile",
-					"site": {
-						"filename": "main.go",
-						"line": "202",
-						"column": "35"
-					}
-				},
-				{
-					"name": "path/filepath.Abs",
-					"site": {
-						"filename": "main.go",
-						"line": "268",
-						"column": "35"
-					}
-				},
-				{
-					"name": "path/filepath.abs",
-					"site": {
-						"filename": "path.go",
-						"line": "295",
-						"column": "12"
-					}
-				},
-				{
-					"name": "path/filepath.unixAbs",
-					"site": {
-						"filename": "path_unix.go",
-						"line": "42",
-						"column": "16"
-					}
-				},
-				{
-					"name": "os.Getwd",
-					"site": {
-						"filename": "path.go",
-						"line": "302",
-						"column": "21"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_OPERATING_SYSTEM",
-			"depPath": "github.com/ericcornelissen/ades.main github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnRepository (*os.unixDirent).IsDir",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.main"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.run",
-					"site": {
-						"filename": "main.go",
-						"line": "65",
-						"column": "13"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets",
-					"site": {
-						"filename": "main.go",
-						"line": "113",
-						"column": "28"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository",
-					"site": {
-						"filename": "main.go",
-						"line": "200",
-						"column": "25"
-					}
-				},
-				{
-					"name": "(*os.unixDirent).IsDir",
-					"site": {
-						"filename": "main.go",
-						"line": "240",
-						"column": "17"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_OPERATING_SYSTEM",
-			"depPath": "github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnRepository (*os.unixDirent).IsDir",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.run"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets",
-					"site": {
-						"filename": "main.go",
-						"line": "113",
-						"column": "28"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository",
-					"site": {
-						"filename": "main.go",
-						"line": "200",
-						"column": "25"
-					}
-				},
-				{
-					"name": "(*os.unixDirent).IsDir",
-					"site": {
-						"filename": "main.go",
-						"line": "240",
-						"column": "17"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_OPERATING_SYSTEM",
-			"depPath": "github.com/ericcornelissen/ades.runOnRepository (*os.unixDirent).IsDir",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository"
-				},
-				{
-					"name": "(*os.unixDirent).IsDir",
-					"site": {
-						"filename": "main.go",
-						"line": "240",
-						"column": "17"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_OPERATING_SYSTEM",
-			"depPath": "github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnRepository (*os.unixDirent).IsDir",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository",
-					"site": {
-						"filename": "main.go",
-						"line": "200",
-						"column": "25"
-					}
-				},
-				{
-					"name": "(*os.unixDirent).IsDir",
-					"site": {
-						"filename": "main.go",
-						"line": "240",
-						"column": "17"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_OPERATING_SYSTEM",
-			"depPath": "github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnRepository (*os.unixDirent).IsDir",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository",
-					"site": {
-						"filename": "main.go",
-						"line": "200",
-						"column": "25"
-					}
-				},
-				{
-					"name": "(*os.unixDirent).IsDir",
-					"site": {
-						"filename": "main.go",
-						"line": "240",
-						"column": "17"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_UNSAFE_POINTER",
 			"depPath": "github.com/ericcornelissen/ades.init regexp.MustCompile regexp.Compile regexp.compile regexp.onePassPrefix (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
 			"path": [
@@ -693,143 +105,7 @@
 			"capabilityType": "CAPABILITY_TYPE_DIRECT"
 		},
 		{
-			"packageName": "main",
-			"capability": "CAPABILITY_UNSAFE_POINTER",
-			"depPath": "github.com/ericcornelissen/ades.main github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.printViolations (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.main"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.run",
-					"site": {
-						"filename": "main.go",
-						"line": "65",
-						"column": "13"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.printViolations",
-					"site": {
-						"filename": "main.go",
-						"line": "132",
-						"column": "29"
-					}
-				},
-				{
-					"name": "(*strings.Builder).WriteRune",
-					"site": {
-						"filename": "output.go",
-						"line": "69",
-						"column": "16"
-					}
-				},
-				{
-					"name": "(*strings.Builder).copyCheck",
-					"site": {
-						"filename": "builder.go",
-						"line": "106",
-						"column": "13"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_UNSAFE_POINTER",
-			"depPath": "github.com/ericcornelissen/ades.printViolation (*strings.Builder).WriteString (*strings.Builder).copyCheck",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.printViolation"
-				},
-				{
-					"name": "(*strings.Builder).WriteString",
-					"site": {
-						"filename": "output.go",
-						"line": "87",
-						"column": "17"
-					}
-				},
-				{
-					"name": "(*strings.Builder).copyCheck",
-					"site": {
-						"filename": "builder.go",
-						"line": "115",
-						"column": "13"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_UNSAFE_POINTER",
-			"depPath": "github.com/ericcornelissen/ades.printViolations (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.printViolations"
-				},
-				{
-					"name": "(*strings.Builder).WriteRune",
-					"site": {
-						"filename": "output.go",
-						"line": "69",
-						"column": "16"
-					}
-				},
-				{
-					"name": "(*strings.Builder).copyCheck",
-					"site": {
-						"filename": "builder.go",
-						"line": "106",
-						"column": "13"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_UNSAFE_POINTER",
-			"depPath": "github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.printViolations (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.run"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.printViolations",
-					"site": {
-						"filename": "main.go",
-						"line": "132",
-						"column": "29"
-					}
-				},
-				{
-					"name": "(*strings.Builder).WriteRune",
-					"site": {
-						"filename": "output.go",
-						"line": "69",
-						"column": "16"
-					}
-				},
-				{
-					"name": "(*strings.Builder).copyCheck",
-					"site": {
-						"filename": "builder.go",
-						"line": "106",
-						"column": "13"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_UNSAFE_POINTER",
 			"depPath": "github.com/ericcornelissen/ades.suggestJavaScriptEnv github.com/ericcornelissen/ades.suggestUseEnv (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
 			"path": [
@@ -840,7 +116,7 @@
 					"name": "github.com/ericcornelissen/ades.suggestUseEnv",
 					"site": {
 						"filename": "rules.go",
-						"line": "287",
+						"line": "340",
 						"column": "22"
 					}
 				},
@@ -848,7 +124,7 @@
 					"name": "(*strings.Builder).WriteRune",
 					"site": {
 						"filename": "rules.go",
-						"line": "305",
+						"line": "358",
 						"column": "14"
 					}
 				},
@@ -865,7 +141,7 @@
 			"capabilityType": "CAPABILITY_TYPE_DIRECT"
 		},
 		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_UNSAFE_POINTER",
 			"depPath": "github.com/ericcornelissen/ades.suggestJavaScriptLiteralEnv github.com/ericcornelissen/ades.suggestUseEnv (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
 			"path": [
@@ -876,7 +152,7 @@
 					"name": "github.com/ericcornelissen/ades.suggestUseEnv",
 					"site": {
 						"filename": "rules.go",
-						"line": "291",
+						"line": "344",
 						"column": "22"
 					}
 				},
@@ -884,7 +160,7 @@
 					"name": "(*strings.Builder).WriteRune",
 					"site": {
 						"filename": "rules.go",
-						"line": "305",
+						"line": "358",
 						"column": "14"
 					}
 				},
@@ -901,7 +177,7 @@
 			"capabilityType": "CAPABILITY_TYPE_DIRECT"
 		},
 		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_UNSAFE_POINTER",
 			"depPath": "github.com/ericcornelissen/ades.suggestShellEnv github.com/ericcornelissen/ades.suggestUseEnv (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
 			"path": [
@@ -912,7 +188,7 @@
 					"name": "github.com/ericcornelissen/ades.suggestUseEnv",
 					"site": {
 						"filename": "rules.go",
-						"line": "295",
+						"line": "348",
 						"column": "22"
 					}
 				},
@@ -920,7 +196,7 @@
 					"name": "(*strings.Builder).WriteRune",
 					"site": {
 						"filename": "rules.go",
-						"line": "305",
+						"line": "358",
 						"column": "14"
 					}
 				},
@@ -937,7 +213,7 @@
 			"capabilityType": "CAPABILITY_TYPE_DIRECT"
 		},
 		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_UNSAFE_POINTER",
 			"depPath": "github.com/ericcornelissen/ades.suggestUseEnv (*strings.Builder).WriteRune (*strings.Builder).copyCheck",
 			"path": [
@@ -948,7 +224,7 @@
 					"name": "(*strings.Builder).WriteRune",
 					"site": {
 						"filename": "rules.go",
-						"line": "305",
+						"line": "358",
 						"column": "14"
 					}
 				},
@@ -965,7 +241,7 @@
 			"capabilityType": "CAPABILITY_TYPE_DIRECT"
 		},
 		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_REFLECT",
 			"depPath": "github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
 			"path": [
@@ -1009,636 +285,12 @@
 			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
 		},
 		{
-			"packageName": "main",
+			"packageName": "ades",
 			"capability": "CAPABILITY_REFLECT",
 			"depPath": "github.com/ericcornelissen/ades.ParseWorkflow gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
 			"path": [
 				{
 					"name": "github.com/ericcornelissen/ades.ParseWorkflow"
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "48",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.init encoding/json.init reflect.TypeFor[encoding.TextMarshaler]",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.init"
-				},
-				{
-					"name": "encoding/json.init"
-				},
-				{
-					"name": "reflect.TypeFor[encoding.TextMarshaler]",
-					"site": {
-						"filename": "encode.go",
-						"line": "373",
-						"column": "61"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.main github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.printJson encoding/json.Marshal (*encoding/json.encodeState).marshal (*encoding/json.encodeState).reflectValue (encoding/json.floatEncoder).encode$bound (encoding/json.floatEncoder).encode",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.main"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.run",
-					"site": {
-						"filename": "main.go",
-						"line": "65",
-						"column": "13"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.printJson",
-					"site": {
-						"filename": "main.go",
-						"line": "121",
-						"column": "24"
-					}
-				},
-				{
-					"name": "encoding/json.Marshal",
-					"site": {
-						"filename": "output.go",
-						"line": "57",
-						"column": "30"
-					}
-				},
-				{
-					"name": "(*encoding/json.encodeState).marshal",
-					"site": {
-						"filename": "encode.go",
-						"line": "163",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*encoding/json.encodeState).reflectValue",
-					"site": {
-						"filename": "encode.go",
-						"line": "297",
-						"column": "16"
-					}
-				},
-				{
-					"name": "(encoding/json.floatEncoder).encode$bound",
-					"site": {
-						"filename": "encode.go",
-						"line": "321",
-						"column": "17"
-					}
-				},
-				{
-					"name": "(encoding/json.floatEncoder).encode"
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.printJson encoding/json.Marshal (*encoding/json.encodeState).marshal (*encoding/json.encodeState).reflectValue (encoding/json.floatEncoder).encode$bound (encoding/json.floatEncoder).encode",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.printJson"
-				},
-				{
-					"name": "encoding/json.Marshal",
-					"site": {
-						"filename": "output.go",
-						"line": "57",
-						"column": "30"
-					}
-				},
-				{
-					"name": "(*encoding/json.encodeState).marshal",
-					"site": {
-						"filename": "encode.go",
-						"line": "163",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*encoding/json.encodeState).reflectValue",
-					"site": {
-						"filename": "encode.go",
-						"line": "297",
-						"column": "16"
-					}
-				},
-				{
-					"name": "(encoding/json.floatEncoder).encode$bound",
-					"site": {
-						"filename": "encode.go",
-						"line": "321",
-						"column": "17"
-					}
-				},
-				{
-					"name": "(encoding/json.floatEncoder).encode"
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.run github.com/ericcornelissen/ades.printJson encoding/json.Marshal (*encoding/json.encodeState).marshal (*encoding/json.encodeState).reflectValue (encoding/json.floatEncoder).encode$bound (encoding/json.floatEncoder).encode",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.run"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.printJson",
-					"site": {
-						"filename": "main.go",
-						"line": "121",
-						"column": "24"
-					}
-				},
-				{
-					"name": "encoding/json.Marshal",
-					"site": {
-						"filename": "output.go",
-						"line": "57",
-						"column": "30"
-					}
-				},
-				{
-					"name": "(*encoding/json.encodeState).marshal",
-					"site": {
-						"filename": "encode.go",
-						"line": "163",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*encoding/json.encodeState).reflectValue",
-					"site": {
-						"filename": "encode.go",
-						"line": "297",
-						"column": "16"
-					}
-				},
-				{
-					"name": "(encoding/json.floatEncoder).encode$bound",
-					"site": {
-						"filename": "encode.go",
-						"line": "321",
-						"column": "17"
-					}
-				},
-				{
-					"name": "(encoding/json.floatEncoder).encode"
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_DIRECT"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.runOnFile github.com/ericcornelissen/ades.tryManifest github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.tryManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "282",
-						"column": "21"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "289",
-						"column": "32"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "69",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.runOnRepository github.com/ericcornelissen/ades.runOnFile github.com/ericcornelissen/ades.tryManifest github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnRepository"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile",
-					"site": {
-						"filename": "main.go",
-						"line": "221",
-						"column": "37"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.tryManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "282",
-						"column": "21"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "289",
-						"column": "32"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "69",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.runOnStdin github.com/ericcornelissen/ades.tryManifest github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnStdin"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.tryManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "160",
-						"column": "39"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "289",
-						"column": "32"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "69",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnFile github.com/ericcornelissen/ades.tryManifest github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile",
-					"site": {
-						"filename": "main.go",
-						"line": "202",
-						"column": "35"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.tryManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "282",
-						"column": "21"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "289",
-						"column": "32"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "69",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.runOnTargets github.com/ericcornelissen/ades.runOnTarget github.com/ericcornelissen/ades.runOnFile github.com/ericcornelissen/ades.tryManifest github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTargets"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnTarget",
-					"site": {
-						"filename": "main.go",
-						"line": "173",
-						"column": "33"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.runOnFile",
-					"site": {
-						"filename": "main.go",
-						"line": "202",
-						"column": "35"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.tryManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "282",
-						"column": "21"
-					}
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "289",
-						"column": "32"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "69",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.tryManifest github.com/ericcornelissen/ades.ParseManifest gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.tryManifest"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseManifest",
-					"site": {
-						"filename": "main.go",
-						"line": "289",
-						"column": "32"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.Unmarshal",
-					"site": {
-						"filename": "parse.go",
-						"line": "69",
-						"column": "26"
-					}
-				},
-				{
-					"name": "gopkg.in/yaml.v3.unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "89",
-						"column": "18"
-					}
-				},
-				{
-					"name": "(*gopkg.in/yaml.v3.decoder).unmarshal",
-					"site": {
-						"filename": "yaml.go",
-						"line": "167",
-						"column": "14"
-					}
-				},
-				{
-					"name": "(reflect.Value).Set",
-					"site": {
-						"filename": "decode.go",
-						"line": "493",
-						"column": "10"
-					}
-				}
-			],
-			"packageDir": "github.com/ericcornelissen/ades",
-			"capabilityType": "CAPABILITY_TYPE_TRANSITIVE"
-		},
-		{
-			"packageName": "main",
-			"capability": "CAPABILITY_REFLECT",
-			"depPath": "github.com/ericcornelissen/ades.tryWorkflow github.com/ericcornelissen/ades.ParseWorkflow gopkg.in/yaml.v3.Unmarshal gopkg.in/yaml.v3.unmarshal (*gopkg.in/yaml.v3.decoder).unmarshal (reflect.Value).Set",
-			"path": [
-				{
-					"name": "github.com/ericcornelissen/ades.tryWorkflow"
-				},
-				{
-					"name": "github.com/ericcornelissen/ades.ParseWorkflow",
-					"site": {
-						"filename": "main.go",
-						"line": "298",
-						"column": "32"
-					}
 				},
 				{
 					"name": "gopkg.in/yaml.v3.Unmarshal",

--- a/cmd/ades/main_test.go
+++ b/cmd/ades/main_test.go
@@ -35,12 +35,12 @@ func TestMain(m *testing.M) {
 
 func TestCli(t *testing.T) {
 	testscript.Run(t, testscript.Params{
-		Dir: "test",
+		Dir: "../../test",
 	})
 }
 
 func TestJsonSchema(t *testing.T) {
-	schema, err := jsonschema.Compile("schema.json")
+	schema, err := jsonschema.Compile("../../schema.json")
 	if err != nil {
 		t.Fatalf("schema.json is not a valid JSON Schema: %v", err)
 	}

--- a/cmd/ades/output.go
+++ b/cmd/ades/output.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/ericcornelissen/ades"
 )
 
 type jsonOutput struct {
@@ -34,7 +36,7 @@ type jsonViolation struct {
 	Problem string `json:"problem"`
 }
 
-func printJson(rawViolations map[string]map[string][]Violation) string {
+func printJson(rawViolations map[string]map[string][]ades.Violation) string {
 	violations := make([]jsonViolation, 0)
 	for target, targetViolations := range rawViolations {
 		for file, fileViolations := range targetViolations {
@@ -58,7 +60,7 @@ func printJson(rawViolations map[string]map[string][]Violation) string {
 	return string(jsonBytes)
 }
 
-func printViolations(violations map[string][]Violation, suggestions bool) string {
+func printViolations(violations map[string][]ades.Violation, suggestions bool) string {
 	clean := true
 
 	var sb strings.Builder
@@ -81,7 +83,7 @@ func printViolations(violations map[string][]Violation, suggestions bool) string
 	}
 }
 
-func printViolation(violation *Violation, suggestions bool) string {
+func printViolation(violation *ades.Violation, suggestions bool) string {
 	var sb strings.Builder
 	if violation.JobId == "" {
 		sb.WriteString(fmt.Sprintf("  step %q has %q", violation.StepId, violation.Problem))
@@ -90,8 +92,7 @@ func printViolation(violation *Violation, suggestions bool) string {
 	}
 
 	if suggestions {
-		r, _ := findRule(violation.RuleId)
-		suggestion := r.suggestion(violation)
+		suggestion, _ := ades.Suggestion(violation)
 
 		sb.WriteString(", suggestion:\n")
 		sb.WriteString(suggestion)

--- a/cmd/ades/output_test.go
+++ b/cmd/ades/output_test.go
@@ -18,49 +18,51 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/ericcornelissen/ades"
 )
 
 func TestPrintJson(t *testing.T) {
 	type TestCase struct {
 		name       string
-		violations func() map[string]map[string][]Violation
+		violations func() map[string]map[string][]ades.Violation
 		want       string
 	}
 
 	testCases := []TestCase{
 		{
 			name: "No targets",
-			violations: func() map[string]map[string][]Violation {
-				return make(map[string]map[string][]Violation)
+			violations: func() map[string]map[string][]ades.Violation {
+				return make(map[string]map[string][]ades.Violation)
 			},
 			want: `{"problems":[]}`,
 		},
 		{
 			name: "target without files",
-			violations: func() map[string]map[string][]Violation {
-				m := make(map[string]map[string][]Violation)
-				m["foobar"] = make(map[string][]Violation)
+			violations: func() map[string]map[string][]ades.Violation {
+				m := make(map[string]map[string][]ades.Violation)
+				m["foobar"] = make(map[string][]ades.Violation)
 				return m
 			},
 			want: `{"problems":[]}`,
 		},
 		{
 			name: "target with files without violations",
-			violations: func() map[string]map[string][]Violation {
-				m := make(map[string]map[string][]Violation)
-				m["foo"] = make(map[string][]Violation)
-				m["foo"]["bar"] = make([]Violation, 0)
+			violations: func() map[string]map[string][]ades.Violation {
+				m := make(map[string]map[string][]ades.Violation)
+				m["foo"] = make(map[string][]ades.Violation)
+				m["foo"]["bar"] = make([]ades.Violation, 0)
 				return m
 			},
 			want: `{"problems":[]}`,
 		},
 		{
 			name: "target with files with violations",
-			violations: func() map[string]map[string][]Violation {
-				m := make(map[string]map[string][]Violation)
-				m["foo"] = make(map[string][]Violation)
-				m["foo"]["bar"] = make([]Violation, 1)
-				m["foo"]["bar"][0] = Violation{
+			violations: func() map[string]map[string][]ades.Violation {
+				m := make(map[string]map[string][]ades.Violation)
+				m["foo"] = make(map[string][]ades.Violation)
+				m["foo"]["bar"] = make([]ades.Violation, 1)
+				m["foo"]["bar"][0] = ades.Violation{
 					JobId:   "4",
 					StepId:  "2",
 					Problem: "${{ foo.bar }}",
@@ -85,7 +87,7 @@ func TestPrintJson(t *testing.T) {
 func TestPrintViolations(t *testing.T) {
 	type TestCase struct {
 		name            string
-		violations      func() map[string][]Violation
+		violations      func() map[string][]ades.Violation
 		want            string
 		wantSuggestions string
 	}
@@ -93,8 +95,8 @@ func TestPrintViolations(t *testing.T) {
 	testCases := []TestCase{
 		{
 			name: "No files",
-			violations: func() map[string][]Violation {
-				return make(map[string][]Violation)
+			violations: func() map[string][]ades.Violation {
+				return make(map[string][]ades.Violation)
 			},
 			want: `Ok
 `,
@@ -103,9 +105,9 @@ func TestPrintViolations(t *testing.T) {
 		},
 		{
 			name: "File without violations",
-			violations: func() map[string][]Violation {
-				m := make(map[string][]Violation)
-				m["workflow.yml"] = make([]Violation, 0)
+			violations: func() map[string][]ades.Violation {
+				m := make(map[string][]ades.Violation)
+				m["workflow.yml"] = make([]ades.Violation, 0)
 				return m
 			},
 			want: `Ok
@@ -115,10 +117,10 @@ func TestPrintViolations(t *testing.T) {
 		},
 		{
 			name: "Workflow with a violation",
-			violations: func() map[string][]Violation {
-				m := make(map[string][]Violation)
-				m["workflow.yml"] = make([]Violation, 1)
-				m["workflow.yml"][0] = Violation{
+			violations: func() map[string][]ades.Violation {
+				m := make(map[string][]ades.Violation)
+				m["workflow.yml"] = make([]ades.Violation, 1)
+				m["workflow.yml"][0] = ades.Violation{
 					JobId:   "4",
 					StepId:  "2",
 					Problem: "${{ foo.bar }}",
@@ -134,10 +136,10 @@ func TestPrintViolations(t *testing.T) {
 		},
 		{
 			name: "Manifest with a violation",
-			violations: func() map[string][]Violation {
-				m := make(map[string][]Violation)
-				m["action.yml"] = make([]Violation, 1)
-				m["action.yml"][0] = Violation{
+			violations: func() map[string][]ades.Violation {
+				m := make(map[string][]ades.Violation)
+				m["action.yml"] = make([]ades.Violation, 1)
+				m["action.yml"][0] = ades.Violation{
 					StepId:  "2",
 					Problem: "${{ foo.bar }}",
 					RuleId:  "ADES100",

--- a/doc.go
+++ b/doc.go
@@ -20,4 +20,4 @@
 // It is primarily intended to be used as a CLI application, but also exports
 // its functionality for programmatic use. For programmatic use, note that this
 // project does not use semantic versioning.
-package main
+package ades

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -22,7 +22,7 @@
 
 //go:build mutation
 
-package main_test
+package ades_test
 
 import (
 	"testing"

--- a/parse.go
+++ b/parse.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package ades
 
 import (
 	"errors"

--- a/parse_test.go
+++ b/parse_test.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package ades
 
 import "testing"
 

--- a/rules.go
+++ b/rules.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package ades
 
 import (
 	"fmt"
@@ -296,32 +296,44 @@ func isBeforeVersion(uses *StepUses, version string) bool {
 	return semver.Compare(version, uses.Ref) > 0
 }
 
-func explainRule(ruleId string) (string, error) {
-	r, ok := findRule(ruleId)
-	if !ok {
-		return "", fmt.Errorf("unknown rule %q", ruleId)
+// Explain returns an explanation for a rule.
+func Explain(ruleId string) (string, error) {
+	r, err := findRule(ruleId)
+	if err != nil {
+		return "", err
 	}
 
 	explanation := fmt.Sprintf("%s - %s\n%s", r.id, r.title, r.description)
 	return explanation, nil
 }
 
-func findRule(ruleId string) (rule, bool) {
+// Suggestion returns a suggestion for the violation.
+func Suggestion(violation *Violation) (string, error) {
+	ruleId := violation.RuleId
+	r, err := findRule(ruleId)
+	if err != nil {
+		return "", err
+	}
+
+	return r.suggestion(violation), nil
+}
+
+func findRule(ruleId string) (rule, error) {
 	for _, rs := range actionRules {
 		for _, r := range rs {
 			if r.rule.id == ruleId {
-				return r.rule, true
+				return r.rule, nil
 			}
 		}
 	}
 
 	for _, r := range stepRules {
 		if r.rule.id == ruleId {
-			return r.rule, true
+			return r.rule, nil
 		}
 	}
 
-	return rule{}, false
+	return rule{}, fmt.Errorf("unknown rule %q", ruleId)
 }
 
 func suggestJavaScriptEnv(violation *Violation) string {

--- a/tools.go
+++ b/tools.go
@@ -19,7 +19,7 @@
 
 //go:build tools
 
-package main
+package ades
 
 import (
 	_ "4d63.com/gochecknoinits"


### PR DESCRIPTION
Relates to #20, #62, #174
Supports #173

## Summary

This changes the package name of the project root to `ades` so that it can be imported. The `ades` command is now in the cmd directory (per the Go convention) and uses the `ades` library to do its job.