### PR TITLE
Add rules for `sergeysova/jq-action`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -118,6 +118,36 @@ it can be made safer by converting it into:
   #                           | Replace the expression with the environment variable
 ```
 
+## ADES104 - Expression in `sergeysova/jq-action` command
+
+When a workflow expression appears in the command  input of `sergeysova/jq-action` you can avoid any
+potential attack by extracting the expression into an environment variable and using the environment
+variable instead.
+
+For example, given the workflow snippet:
+
+```yaml
+- name: Example step
+  uses: sergeysova/jq-action@v2
+  with:
+    cmd: jq .version ${{ github.event.inputs.file }} -r
+```
+
+it can be made safer by converting it into:
+
+```yaml
+- name: Example step
+  uses: sergeysova/jq-action@v2
+  env
+    FILE: ${{ github.event.inputs.file }} # <- Assign the expression to an environment variable
+  with:
+  #                  | Note: use double quotes to avoid argument splitting
+  #                  v
+    cmd: jq .version "$FILE" -r
+  #                   ^^^^^
+  #                   | Replace the expression with the environment variable
+```
+
 ## ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
 
 When a workflow expression is used in the tag input for `ericcornelissen/git-tag-annotation-action`

--- a/test/rules.txtar
+++ b/test/rules.txtar
@@ -22,6 +22,12 @@ stdout 'ADES102'
 stdout 'ADES103'
 ! stderr .
 
+# ADES104
+! exec ades ades104.yml
+! stdout 'Ok'
+stdout 'ADES104'
+! stderr .
+
 # ADES200
 ! exec ades ades200.yml
 ! stdout 'Ok'
@@ -78,6 +84,17 @@ jobs:
     - uses: roots/issue-closer@v1
       with:
         pr-close-message: Closing ${{ github.event.issue.title }}
+-- ades104.yml --
+name: Example workflow with a ADES104 violation
+on: [push]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: sergeysova/jq-action@v2
+      with:
+        cmd: jq .version ${{ github.event.inputs.file }} -r
 -- ades200.yml --
 name: Example workflow with a ADES200 violation
 on: [push]


### PR DESCRIPTION
Relates to #176, #179

## Summary

Extend the rules of ades to include a dangerous uses of workflow expression in the [`sergeysova/jq-action` action](https://github.com/sergeysova/jq-action/). The implementation is based on the guidelines for new rules from the Contributing Guidelines. Thee rule was added based on its inclusion in <https://boostsecurityio.github.io/lotp/> after validating the impact (and suggestion) with two uses like:

    - name: Unsafe test example
      uses: sergeysova/jq-action@v2
      with:
        cmd: jq .version ${{ github.event.inputs.file }} -r
    - name: Safe test example
      uses: sergeysova/jq-action@v2
      env:
        FILE: ${{ github.event.inputs.file }}
      with:
        cmd: jq .version "$FILE" -r