### PR TITLE
Automatic fixes for `ADES102`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ go run github.com/ericcornelissen/ades/cmd/ades@latest .
 - Reports dangerous uses of expressions in [`run:`] directives, [`actions/github-script`] scripts,
   and known problematic action inputs.
 - _(Experimental)_ Report dangerous uses of expressions in known vulnerable actions.
-- Provides suggested fixes.
+- Provides suggested fixes and _(Experimental)_ fully automated fixes.
 - Configurable sensitivity.
 - Machine & human readable output formats.
 

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -130,6 +130,12 @@ func TestAnalyzeManifest(t *testing.T) {
 			if got, want := len(violations), tt.want; got != want {
 				t.Fatalf("Unexpected number of violations (got %d, want %d)", got, want)
 			}
+
+			for _, violation := range violations {
+				if got, want := violation.source, &tt.manifest; got != want {
+					t.Errorf("Violation source is not the manifest (got %v, want %v)", got, want)
+				}
+			}
 		})
 	}
 
@@ -262,6 +268,12 @@ func TestAnalyzeWorkflow(t *testing.T) {
 			violations := AnalyzeWorkflow(&tt.workflow, tt.matcher)
 			if got, want := len(violations), tt.want; got != want {
 				t.Fatalf("Unexpected number of violations (got %d, want %d)", got, tt.want)
+			}
+
+			for _, violation := range violations {
+				if got, want := violation.source, &tt.workflow; got != want {
+					t.Errorf("Violation source is not the workflow (got %v, want %v)", got, want)
+				}
 			}
 		})
 	}
@@ -406,6 +418,10 @@ func TestAnalyzeJob(t *testing.T) {
 			}
 
 			for i, violation := range violations {
+				if got, want := violation.jobKey, tt.id; got != want {
+					t.Errorf("Unexpected job key for violation %d (got %q, want %q)", i, got, want)
+				}
+
 				if got, want := violation.JobId, tt.wantId; got != want {
 					t.Errorf("Unexpected job ID for violation %d (got %q, want %q)", i, got, want)
 				}
@@ -545,6 +561,10 @@ func TestAnalyzeStep(t *testing.T) {
 			}
 
 			for i, violation := range violations {
+				if got, want := violation.stepIndex, tt.id; got != want {
+					t.Errorf("Unexpected step index for violation #%d (got %q, want %q)", i, got, want)
+				}
+
 				if got, want := violation.StepId, tt.wantStepId; got != want {
 					t.Errorf("Unexpected step id for violation #%d (got %q, want %q)", i, got, want)
 				}

--- a/parse.go
+++ b/parse.go
@@ -37,6 +37,7 @@ type WorkflowJob struct {
 // JobStep is a (simplified) representation of a workflow job step object.
 type JobStep struct {
 	With map[string]string `yaml:"with"`
+	Env  map[string]string `yaml:"env"`
 	Name string            `yaml:"name"`
 	Run  string            `yaml:"run"`
 	Uses string            `yaml:"uses"`

--- a/test/fix.txtar
+++ b/test/fix.txtar
@@ -1,0 +1,491 @@
+# ADES100 - Manifest (no fix available)
+! exec ades -fix-experimental ADES100/action.yml
+! stdout 'Ok'
+! stderr .
+cmp ADES100/action.yml .want/ADES100/action.yml
+
+# ADES102 - Manifest - with environment variables (#1)
+exec ades -fix-experimental ADES102/manifest/with-env-1/action.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/with-env-1/action.yml .want/ADES102/manifest/with-env-1/action.yml
+
+# ADES102 - Manifest - with environment variables (#2)
+exec ades -fix-experimental ADES102/manifest/with-env-2/action.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/with-env-2/action.yml .want/ADES102/manifest/with-env-2/action.yml
+
+# ADES102 - Manifest - without environment variables (#1)
+exec ades -fix-experimental ADES102/manifest/without-env-1/action.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/without-env-1/action.yml .want/ADES102/manifest/without-env-1/action.yml
+
+# ADES102 - Manifest - without environment variables (#2)
+exec ades -fix-experimental ADES102/manifest/without-env-2/action.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/without-env-2/action.yml .want/ADES102/manifest/without-env-2/action.yml
+
+# ADES102 - Manifest - name taken
+! exec ades -fix-experimental ADES102/manifest/name-taken/action.yml
+! stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/name-taken/action.yml .want/ADES102/manifest/name-taken/action.yml
+
+# ADES102 - Manifest - unnamed
+exec ades -fix-experimental ADES102/manifest/unnamed/action.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/unnamed/action.yml .want/ADES102/manifest/unnamed/action.yml
+
+# ADES102 - Manifest - fix + unfixed
+! exec ades -fix-experimental ADES102/manifest/fix-and-unfixed/action.yml
+! stdout 'Ok'
+! stderr .
+cmp ADES102/manifest/fix-and-unfixed/action.yml .want/ADES102/manifest/fix-and-unfixed/action.yml
+
+# ADES102 - Workflow - with environment variables (#1)
+exec ades -fix-experimental ADES102/workflow/with-env-1/workflow.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/with-env-1/workflow.yml .want/ADES102/workflow/with-env-1/workflow.yml
+
+# ADES102 - Workflow - with environment variables (#2)
+exec ades -fix-experimental ADES102/workflow/with-env-2/workflow.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/with-env-2/workflow.yml .want/ADES102/workflow/with-env-2/workflow.yml
+
+# ADES102 - Workflow - without environment variables (#1)
+exec ades -fix-experimental ADES102/workflow/without-env-1/workflow.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/without-env-1/workflow.yml .want/ADES102/workflow/without-env-1/workflow.yml
+
+# ADES102 - Workflow - without environment variables (#2)
+exec ades -fix-experimental ADES102/workflow/without-env-2/workflow.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/without-env-2/workflow.yml .want/ADES102/workflow/without-env-2/workflow.yml
+
+# ADES102 - Workflow - name taken
+! exec ades -fix-experimental ADES102/workflow/name-taken/workflow.yml
+! stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/name-taken/workflow.yml .want/ADES102/workflow/name-taken/workflow.yml
+
+# ADES102 - Workflow - unnamed step
+exec ades -fix-experimental ADES102/workflow/unnamed/workflow.yml
+stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/unnamed/workflow.yml .want/ADES102/workflow/unnamed/workflow.yml
+
+# ADES102 - Workflow - fix + unfixed
+! exec ades -fix-experimental ADES102/workflow/fix-and-unfixed/workflow.yml
+! stdout 'Ok'
+! stderr .
+cmp ADES102/workflow/fix-and-unfixed/workflow.yml .want/ADES102/workflow/fix-and-unfixed/workflow.yml
+
+
+-- ADES100/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe run
+    run: |
+      echo 'Hello ${{ inputs.name }}'
+-- ADES102/manifest/with-env-1/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    env:
+      FOO: BAR
+    with:
+      issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/manifest/with-env-2/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        FOO: BAR
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/manifest/without-env-1/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    with:
+      issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/manifest/without-env-2/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/manifest/name-taken/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    env:
+      TITLE: taken
+    with:
+      issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/manifest/unnamed/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - uses: roots/issue-closer@v1
+    with:
+      issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/manifest/fix-and-unfixed/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - run: echo '${{ github.event.issue.title }}'
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    with:
+      issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/with-env-1/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        FOO: bar
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/with-env-2/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unsafe uses
+        uses: roots/issue-closer@v1
+        env:
+          FOO: bar
+        with:
+          issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/without-env-1/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/without-env-2/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unsafe uses
+        uses: roots/issue-closer@v1
+        with:
+          issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/name-taken/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        TITLE: taken
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/unnamed/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - uses: roots/issue-closer@v1
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ADES102/workflow/fix-and-unfixed/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo '${{ github.event.issue.title }}'
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- .want/ADES100/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe run
+    run: |
+      echo 'Hello ${{ inputs.name }}'
+-- .want/ADES102/manifest/with-env-1/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    env:
+      FOO: BAR
+      TITLE: ${{ github.event.issue.title }}
+    with:
+      issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/manifest/with-env-2/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        FOO: BAR
+        TITLE: ${{ github.event.issue.title }}
+      with:
+        issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/manifest/without-env-1/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    env:
+      TITLE: ${{ github.event.issue.title }}
+    with:
+      issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/manifest/without-env-2/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        TITLE: ${{ github.event.issue.title }}
+      with:
+        issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/manifest/name-taken/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    env:
+      TITLE: taken
+    with:
+      issue-close-message: Closing ${{ github.event.issue.title }}
+-- .want/ADES102/manifest/unnamed/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - uses: roots/issue-closer@v1
+    env:
+      TITLE: ${{ github.event.issue.title }}
+    with:
+      issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/manifest/fix-and-unfixed/action.yml --
+name: Example unsafe action
+description: Sample action for testing _ades_
+
+runs:
+  using: composite
+  steps:
+  - run: echo '${{ github.event.issue.title }}'
+  - name: Unsafe uses
+    uses: roots/issue-closer@v1
+    env:
+      TITLE: ${{ github.event.issue.title }}
+    with:
+      issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/workflow/with-env-1/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        FOO: bar
+        TITLE: ${{ github.event.issue.title }}
+      with:
+        issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/workflow/with-env-2/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unsafe uses
+        uses: roots/issue-closer@v1
+        env:
+          FOO: bar
+          TITLE: ${{ github.event.issue.title }}
+        with:
+          issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/workflow/without-env-1/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        TITLE: ${{ github.event.issue.title }}
+      with:
+        issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/workflow/without-env-2/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unsafe uses
+        uses: roots/issue-closer@v1
+        env:
+          TITLE: ${{ github.event.issue.title }}
+        with:
+          issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/workflow/name-taken/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        TITLE: taken
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- .want/ADES102/workflow/unnamed/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - uses: roots/issue-closer@v1
+      env:
+        TITLE: ${{ github.event.issue.title }}
+      with:
+        issue-close-message: Closing ${process.env.TITLE}
+-- .want/ADES102/workflow/fix-and-unfixed/workflow.yml --
+name: Example unsafe workflow
+on: [push]
+
+jobs:
+  example:
+    name: Example unsafe job
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo '${{ github.event.issue.title }}'
+    - name: Unsafe uses
+      uses: roots/issue-closer@v1
+      env:
+        TITLE: ${{ github.event.issue.title }}
+      with:
+        issue-close-message: Closing ${process.env.TITLE}


### PR DESCRIPTION
Relates to #42

## Summary

This implements (a POC of) automatic fixing functionality for the [`ADES102`](https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades102---expression-in-rootsissue-closer-issue-close-message) rule. The nature of the problem identified by this rule makes it relatively straightforward to resolve because there is no need to take the context into account - in other words a straightforward find-and-replace strategy is possible.

~~Still, this currently runs into the problem of maintaining the formatting of the original source, as seen in the `fix.txtar` test file.~~ Formatting is now mostly maintained by using regular expressions to do the replacement. This, however, could be brittle - which is fine for an experimental feature (where the brittleness can be tested safely).