### PR TITLE
Use custom ids to avoid the map of rule IDs to links

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -5,7 +5,7 @@
 All rules supported by `ades` are listed and explained in this document, including an example of how
 to address it.
 
-## ADES100 - Expression in `run:` directive
+## <a id="ADES100"></a> ADES100 - Expression in `run:` directive
 
 When a workflow expression appears in a `run:` directive you can avoid any potential attacks by
 extracting the expression into an environment variable and using the environment variable instead.
@@ -32,7 +32,7 @@ it can be made safer by converting it into:
 #        | Note: the use of double quotes is required in this example (for interpolation)
 ```
 
-## ADES101 - Expression in `actions/github-script` script
+## <a id="ADES101"></a> ADES101 - Expression in `actions/github-script` script
 
 When a workflow expression appears in a `actions/github-script` script you can avoid any potential
 attacks by extracting the expression into an environment variable and using the environment variable
@@ -62,7 +62,7 @@ it can be made safer by converting it into:
 #                       | Note: the use of backticks is required in this example (for interpolation)
 ```
 
-## ADES102 - Expression in `roots/issue-closer` issue close message
+## <a id="ADES102"></a> ADES102 - Expression in `roots/issue-closer` issue close message
 
 When a workflow expression appears in the issue close message of `roots/issue-closer` it is
 interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
@@ -90,7 +90,7 @@ it can be made safer by converting it into:
   #                              | Replace the expression with the environment variable
 ```
 
-## ADES103 - Expression in `roots/issue-closer` pull request close message
+## <a id="ADES103"></a> ADES103 - Expression in `roots/issue-closer` pull request close message
 
 When a workflow expression appears in the pull request close message of `roots/issue-closer` it is
 interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
@@ -118,7 +118,7 @@ it can be made safer by converting it into:
   #                           | Replace the expression with the environment variable
 ```
 
-## ADES104 - Expression in `sergeysova/jq-action` command
+## <a id="ADES104"></a> ADES104 - Expression in `sergeysova/jq-action` command
 
 When a workflow expression appears in the command  input of `sergeysova/jq-action` you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
@@ -148,7 +148,7 @@ it can be made safer by converting it into:
   #                   | Replace the expression with the environment variable
 ```
 
-## ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
+## <a id="ADES200"></a> ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
 
 When a workflow expression is used in the tag input for `ericcornelissen/git-tag-annotation-action`
 in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see [GHSA-hgx2-4pp9-357g].
@@ -156,7 +156,7 @@ To avoid this, upgrade the action to a non-vulnerable version.
 
 [GHSA-hgx2-4pp9-357g]: https://github.com/ericcornelissen/git-tag-annotation-action/security/advisories/GHSA-hgx2-4pp9-357g
 
-## ADES201 - Expression in `kceb/git-message-action` sha input
+## <a id="ADES201"></a> ADES201 - Expression in `kceb/git-message-action` sha input
 
 When a workflow expression is used in the sha input for `kceb/git-message-action` in v1.1.0 or
 earlier it may be used to execute arbitrary shell commands (no vulnerability identifier available).

--- a/web/index.js
+++ b/web/index.js
@@ -18,37 +18,6 @@
 const input = document.getElementById("workflow-input");
 const results = document.getElementById("results");
 
-const RULE_LINKS = new Map([
-  [
-    "ADES100",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades100---expression-in-run-directive",
-  ],
-  [
-    "ADES101",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades101---expression-in-actionsgithub-script-script",
-  ],
-  [
-    "ADES102",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades102---expression-in-rootsissue-closer-issue-close-message",
-  ],
-  [
-    "ADES103",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades103---expression-in-rootsissue-closer-pull-request-close-message",
-  ],
-  [
-    "ADES104",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades104---expression-in-sergeysovajq-action-command",
-  ],
-  [
-    "ADES200",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades200---expression-in-ericcornelissengit-tag-annotation-action-tag-input",
-  ],
-  [
-    "ADES201",
-    "https://github.com/ericcornelissen/ades/blob/main/RULES.md#ades201---expression-in-kcebgit-message-action-sha-input",
-  ],
-]);
-
 async function loadWasm() {
   const go = new Go();
 
@@ -67,7 +36,7 @@ async function loadWasm() {
 
 const htmlEncode = {
   ruleId: (ruleId) => {
-    const link = RULE_LINKS.get(ruleId);
+    const link = `https://github.com/ericcornelissen/ades/blob/main/RULES.md#${ruleId}`;
     return `<a href="${link}" rel="noopener" target="_blank">${ruleId}</a>`;
   },
   violation: (violation) => {


### PR DESCRIPTION
Relates to #173

## Summary

Simplify the website code and reduce the work needed to add a new rule by leveraging custom ids in the `RULES.md` documentation to create deterministic anchors.
