### PR TITLE
Use stderr to output errors

### DIFF
--- a/cmd/ades/main.go
+++ b/cmd/ades/main.go
@@ -84,7 +84,7 @@ func run() int {
 	if *flagExplain != "" {
 		explanation, err := ades.Explain(*flagExplain)
 		if err != nil {
-			fmt.Printf("Unknown rule %q\n", *flagExplain)
+			fmt.Fprintf(os.Stderr, "Unknown rule %q\n", *flagExplain)
 			return exitError
 		} else {
 			fmt.Println(explanation)
@@ -96,7 +96,7 @@ func run() int {
 	if len(targets) == 0 {
 		wd, err := os.Getwd()
 		if err != nil {
-			fmt.Printf("Could not get working directory, use explicit target instead (error: %s)\n", err)
+			fmt.Fprintf(os.Stderr, "Could not get working directory, use explicit target instead (error: %s)\n", err)
 			return exitError
 		}
 
@@ -155,7 +155,7 @@ func runOnStdin() (map[string]map[string][]ades.Violation, bool) {
 
 	violations := make(map[string][]ades.Violation)
 	if workflowViolations, err := tryWorkflow(data); err != nil {
-		fmt.Printf("Could not parse input (error: %s)\n", err)
+		fmt.Fprintf(os.Stderr, "Could not parse input (error: %s)\n", err)
 		return nil, false
 	} else if len(workflowViolations) != 0 {
 		violations["stdin"] = workflowViolations
@@ -185,7 +185,7 @@ func runOnTargets(targets []string) (map[string]map[string][]ades.Violation, boo
 				targetViolations[file] = fileViolations
 			}
 		} else {
-			fmt.Printf("An unexpected error occurred: %s\n", err)
+			fmt.Fprintf(os.Stderr, "An unexpected error occurred: %s\n", err)
 			hasError = true
 		}
 	}
@@ -243,7 +243,7 @@ func runOnRepository(target string) (map[string][]ades.Violation, error) {
 		if fileViolations, err := runOnFile(fullPath); err == nil {
 			violations[path] = fileViolations
 		} else {
-			fmt.Printf("Could not process manifest %q: %v\n", path, err)
+			fmt.Fprintf(os.Stderr, "Could not process manifest %q: %v\n", path, err)
 		}
 
 		return nil
@@ -271,7 +271,7 @@ func runOnRepository(target string) (map[string][]ades.Violation, error) {
 		if workflowViolations, err := runOnFile(fullPath); err == nil {
 			violations[path] = workflowViolations
 		} else {
-			fmt.Printf("Could not process workflow %s: %v\n", entry.Name(), err)
+			fmt.Fprintf(os.Stderr, "Could not process workflow %s: %v\n", entry.Name(), err)
 		}
 
 		return nil

--- a/test/cwd.txtar
+++ b/test/cwd.txtar
@@ -38,16 +38,14 @@ stdout '.github/workflows/unsafe.yaml'
 cd ../invalid-manifest
 
 exec ades
-stdout 'Could not process manifest "action.yml"'
-stdout 'Could not process manifest "action.yaml"'
-! stderr .
+stderr 'Could not process manifest "action.yml"'
+stderr 'Could not process manifest "action.yaml"'
 
 # Invalid workflow
 cd ../invalid-workflow
 
 exec ades
-stdout 'Could not process workflow syntax-error.yml'
-! stderr .
+stderr 'Could not process workflow syntax-error.yml'
 
 
 -- manifests/action.yml --

--- a/test/explain.txtar
+++ b/test/explain.txtar
@@ -5,8 +5,8 @@ cmp stdout $WORK/snapshots/ades100-stdout.txt
 
 # Non-existent rule
 ! exec ades -explain 'foobar'
-stdout 'Unknown rule "foobar"'
-! stderr .
+! stdout .
+stderr 'Unknown rule "foobar"'
 
 
 -- snapshots/ades100-stdout.txt --

--- a/test/stdin.txtar
+++ b/test/stdin.txtar
@@ -25,9 +25,8 @@ stdin .github/workflows/unsafe.yml
 # Not yaml
 stdin not-yaml.txt
 ! exec ades -
-stdout 'Could not parse input'
 ! stdout 'Ok'
-! stderr .
+stderr 'Could not parse input'
 
 
 -- not-yaml.txt --

--- a/test/stdout.txtar
+++ b/test/stdout.txtar
@@ -41,8 +41,8 @@ cmp stdout $WORK/snapshots/suggestion-stdout.txt
 
 # Not found
 ! exec ades 'does-not-exist'
-stdout 'An unexpected error occurred: could not process does-not-exist:'
-! stderr .
+! stdout .
+stderr 'An unexpected error occurred: could not process does-not-exist:'
 
 
 -- project/action.yml --


### PR DESCRIPTION
Relates to #194

## Summary

Update the CLI to write error messages to stderr. This makes semantic sense and additionally allows for obtaining partial successful results from stdout, especially when using the `-json` flag.