### PR TITLE
Add docs for undocument public functions, types, and fields

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -19,13 +19,27 @@ import (
 	"fmt"
 )
 
+// Violation contain information on problematic GitHub Actions Expressions found in a workflow or
+// manifest.
 type Violation struct {
-	JobId   string
-	StepId  string
+	// JobId is an identifier of a job in a GitHub Actions workflow, either the name or key.
+	//
+	// This will be the zero value if the violation is for a GitHub Actions manifest.
+	JobId string
+
+	// StepId is the identifier of a step in a GitHub Actions workflow or manifest, either the name
+	// or index.
+	StepId string
+
+	// Problem is the problematic GitHub Actions Workflow Expression as observed in the workflow or
+	// manifest.
 	Problem string
-	RuleId  string
+
+	// RuleId is the identifier of the ades rule that produced the violation.
+	RuleId string
 }
 
+// AnalyzeManifest analyses a GitHub Actions manifest for problematic GitHub Actions Expressions.
 func AnalyzeManifest(manifest *Manifest, matcher ExprMatcher) []Violation {
 	violations := make([]Violation, 0)
 	if manifest == nil {
@@ -39,6 +53,7 @@ func AnalyzeManifest(manifest *Manifest, matcher ExprMatcher) []Violation {
 	return analyzeSteps(manifest.Runs.Steps, matcher)
 }
 
+// AnalyzeWorkflow analyses a GitHub Actions workflow for problematic GitHub Actions Expressions.
 func AnalyzeWorkflow(workflow *Workflow, matcher ExprMatcher) []Violation {
 	violations := make([]Violation, 0)
 	if workflow == nil {

--- a/parse.go
+++ b/parse.go
@@ -75,8 +75,11 @@ func ParseManifest(data []byte) (Manifest, error) {
 
 // StepUses is a structured representation of a workflow job step `uses:` value.
 type StepUses struct {
+	// Name is the name of the Action that is used. Typically <owner>/<repository>.
 	Name string
-	Ref  string
+
+	// Ref is the git reference used for the Action. Typically a tag ref, branch ref, or commit SHA.
+	Ref string
 }
 
 // ParseUses parses a Github Actions workflow job step's `uses:` value.


### PR DESCRIPTION
## Summary

- Add missing docs for public stuff in [`analyze.go`](https://github.com/ericcornelissen/ades/blob/a5ce8585a29dfea82891061fa4eebff5b280f0a8/analyze.go).
- Add docs for the fields of the [`StepUses`](https://github.com/ericcornelissen/ades/blob/a5ce8585a29dfea82891061fa4eebff5b280f0a8/parse.go#L77-L80) type because they might not be self-evident.