### PR TITLE
Correct typo in example fix for `ADES104`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -138,7 +138,7 @@ it can be made safer by converting it into:
 ```yaml
 - name: Example step
   uses: sergeysova/jq-action@v2
-  env
+  env:
     FILE: ${{ github.event.inputs.file }} # <- Assign the expression to an environment variable
   with:
   #                  | Note: use double quotes to avoid argument splitting

--- a/rules.go
+++ b/rules.go
@@ -213,7 +213,7 @@ it can be made safer by converting it into:
 
     - name: Example step
       uses: sergeysova/jq-action@v2
-      env
+      env:
         FILE: ${{ github.event.inputs.file }} # <- Assign the expression to an environment variable
       with:
       #                  | Note: use double quotes to avoid argument splitting


### PR DESCRIPTION
Relates to #183

## Summary

Fixes a typo in the example fix for [rule `ADES104`](https://github.com/ericcornelissen/ades/blob/81b7dce80501d65df4d042839586b50f028d8435/RULES.md#-ades104---expression-in-sergeysovajq-action-command) that was duplicated between both the docs and the code.