### PR TITLE
Change wording of "Workflow Expressions" to "GitHub Actions Expressions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Actions Dangerous Expressions Scanner
 
-A simple tool to find dangerous uses of GitHub Actions [Workflow expression]s.
+A simple tool to find dangerous uses of [GitHub Actions Expression]s.
 
 ## Usage
 
@@ -12,7 +12,7 @@ Run the tool from the root of a GitHub repository:
 ades .
 ```
 
-and it will report all detected dangerous uses of workflow expressions.
+and it will report all detected dangerous uses of GitHub Actions Expressions.
 
 You can also use the containerized version of the CLI, for example using Docker:
 
@@ -29,9 +29,9 @@ go run github.com/ericcornelissen/ades/cmd/ades@latest .
 ### Features
 
 - Scans workflow files and action manifests.
-- Reports dangerous uses of workflow expressions in [`run:`] directives, [`actions/github-script`]
-  scripts, and known problematic action inputs.
-- _(Experimental)_ Report dangerous uses of workflow expressions in known vulnerable actions.
+- Reports dangerous uses of expressions in [`run:`] directives, [`actions/github-script`] scripts,
+  and known problematic action inputs.
+- _(Experimental)_ Report dangerous uses of expressions in known vulnerable actions.
 - Provides suggested fixes.
 - Configurable sensitivity.
 - Machine & human readable output formats.
@@ -48,22 +48,22 @@ schema is intended to be stable from one version to the next for longer periods 
 
 ## Background
 
-A [workflow expression] is a string like:
+A [GitHub Actions Expression] is a string like:
 
 ```text
 ${{ <expression> }}
 ```
 
-that may appear in a GitHub Actions workflow and is filled in at runtime. If the value is controlled
-by a malicious actor it could be used to hijack the continuous integration pipeline of a repository.
-GitHub [blogged about this problem] in August of 2023.
+that may appear in a GitHub Actions workflow or manifest and is filled in at runtime. If the value
+is controlled by a malicious actor it could be used to hijack the continuous integration pipeline of
+a repository. GitHub [blogged about this problem] in August of 2023.
 
 ## Philosophy
 
 This project aims to provide a tool aimed at helping developers avoid the problem of injection
-through expressions altogether. Instead of reporting on problematic uses of workflow expressions,
-`ades` reports on all potentially dangerous uses of workflow expressions, nudging developers to use
-safe alternatives from the get-go.
+through expressions altogether. Instead of reporting on known problematic uses of expressions,
+`ades` reports on all potentially dangerous uses of expressions, nudging developers to use safe
+alternatives from the get-go.
 
 The motivation behind this is twofold. First, it makes the tool much simpler and faster. Second, it
 acknowledges that software development is dynamic and making changes some time after a piece of code
@@ -136,8 +136,8 @@ Documentation License v1.3] for the full license text.
 [characterizing the security of github ci workflows]: https://www.usenix.org/conference/usenixsecurity22/presentation/koishybayev
 [copying.txt]: ./COPYING.txt
 [cycodelabs/raven]: https://github.com/CycodeLabs/raven
+[github actions expression]: https://docs.github.com/en/actions/learn-github-actions/expressions
 [gnu free documentation license v1.3]: https://www.gnu.org/licenses/fdl-1.3.en.html
 [on the outdatedness of workflows in the github actions ecosystem]: https://www.sciencedirect.com/science/article/pii/S0164121223002224
 [rules.md]: ./RULES.md
 [stepsecurity]: https://www.stepsecurity.io/
-[workflow expression]: https://docs.github.com/en/actions/learn-github-actions/expressions

--- a/RULES.md
+++ b/RULES.md
@@ -7,8 +7,8 @@ to address it.
 
 ## <a id="ADES100"></a> ADES100 - Expression in `run:` directive
 
-When a workflow expression appears in a `run:` directive you can avoid any potential attacks by
-extracting the expression into an environment variable and using the environment variable instead.
+When an expression appears in a `run:` directive you can avoid any potential attacks by extracting
+the expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -34,8 +34,8 @@ it can be made safer by converting it into:
 
 ## <a id="ADES101"></a> ADES101 - Expression in `actions/github-script` script
 
-When a workflow expression appears in a `actions/github-script` script you can avoid any potential
-attacks by extracting the expression into an environment variable and using the environment variable
+When an expression appears in a `actions/github-script` script you can avoid any potential attacks
+by extracting the expression into an environment variable and using the environment variable
 instead.
 
 For example, given the workflow snippet:
@@ -64,9 +64,9 @@ it can be made safer by converting it into:
 
 ## <a id="ADES102"></a> ADES102 - Expression in `roots/issue-closer` issue close message
 
-When a workflow expression appears in the issue close message of `roots/issue-closer` it is
-interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
-expression into an environment variable and using the environment variable instead.
+When an expression appears in the issue close message of `roots/issue-closer` it is interpreted as
+an ES6-style template literal. You can avoid any potential attacks by extracting the expression into
+an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -92,7 +92,7 @@ it can be made safer by converting it into:
 
 ## <a id="ADES103"></a> ADES103 - Expression in `roots/issue-closer` pull request close message
 
-When a workflow expression appears in the pull request close message of `roots/issue-closer` it is
+When an expression appears in the pull request close message of `roots/issue-closer` it is
 interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
@@ -120,7 +120,7 @@ it can be made safer by converting it into:
 
 ## <a id="ADES104"></a> ADES104 - Expression in `sergeysova/jq-action` command
 
-When a workflow expression appears in the command  input of `sergeysova/jq-action` you can avoid any
+When an expression appears in the command input of `sergeysova/jq-action` you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
 
@@ -150,14 +150,14 @@ it can be made safer by converting it into:
 
 ## <a id="ADES200"></a> ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
 
-When a workflow expression is used in the tag input for `ericcornelissen/git-tag-annotation-action`
-in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see [GHSA-hgx2-4pp9-357g].
-To avoid this, upgrade the action to a non-vulnerable version.
+When an expression is used in the tag input for `ericcornelissen/git-tag-annotation-action` in
+v1.0.0 or earlier it may be used to execute arbitrary shell commands, see [GHSA-hgx2-4pp9-357g]. To
+mitigate this, upgrade the action to a non-vulnerable version.
 
 [GHSA-hgx2-4pp9-357g]: https://github.com/ericcornelissen/git-tag-annotation-action/security/advisories/GHSA-hgx2-4pp9-357g
 
 ## <a id="ADES201"></a> ADES201 - Expression in `kceb/git-message-action` sha input
 
-When a workflow expression is used in the sha input for `kceb/git-message-action` in v1.1.0 or
-earlier it may be used to execute arbitrary shell commands (no vulnerability identifier available).
-To mitigate this, upgrade the action to a non-vulnerable version.
+When an expression is used in the sha input for `kceb/git-message-action` in v1.1.0 or earlier it
+may be used to execute arbitrary shell commands (no vulnerability identifier available). To mitigate
+this, upgrade the action to a non-vulnerable version.

--- a/analyze.go
+++ b/analyze.go
@@ -31,8 +31,7 @@ type Violation struct {
 	// or index.
 	StepId string
 
-	// Problem is the problematic GitHub Actions Workflow Expression as observed in the workflow or
-	// manifest.
+	// Problem is the problematic GitHub Actions Expression as observed in the workflow or manifest.
 	Problem string
 
 	// RuleId is the identifier of the ades rule that produced the violation.

--- a/matchers.go
+++ b/matchers.go
@@ -19,15 +19,15 @@ import (
 	"regexp"
 )
 
-// ExprMatcher is the interface for types that can find GitHub Workflow Expressions in strings.
+// ExprMatcher is the interface for types that can find GitHub Actions Expressions in strings.
 type ExprMatcher interface {
-	// FindAll is the function that returns all relevant GitHub Workflow Expressions in the provided
+	// FindAll is the function that returns all relevant GitHub Actions Expressions in the provided
 	// input.
 	FindAll([]byte) [][]byte
 }
 
 var (
-	// AllMatcher is an ExprMatcher that will find all GitHub Workflow Expressions in strings.
+	// AllMatcher is an ExprMatcher that will find all GitHub Actions Expressions in strings.
 	AllMatcher allExprMatcher
 
 	// ConservativeMatcher is an ExprMatcher that will conservatively find GitHub Workflow

--- a/rules.go
+++ b/rules.go
@@ -48,8 +48,8 @@ var actionRuleActionsGitHubScript = actionRule{
 		id:    "ADES101",
 		title: "Expression in 'actions/github-script' script",
 		description: `
-When a workflow expression appears in a 'actions/github-script' script you can avoid any potential
-attacks by extracting the expression into an environment variable and using the environment variable
+When an expression appears in a 'actions/github-script' script you can avoid any potential attacks
+by extracting the expression into an environment variable and using the environment variable
 instead.
 
 For example, given the workflow snippet:
@@ -86,8 +86,8 @@ var actionRuleEriccornelissenGitTagAnnotationAction = actionRule{
 		id:    "ADES200",
 		title: "Expression in 'ericcornelissen/git-tag-annotation-action' tag input",
 		description: `
-When a workflow expression is used in the tag input for 'ericcornelissen/git-tag-annotation-action'
-in v1.0.0 or earlier it may be used to execute arbitrary shell commands, see GHSA-hgx2-4pp9-357g. To
+When an expression is used in the tag input for 'ericcornelissen/git-tag-annotation-action' in
+v1.0.0 or earlier it may be used to execute arbitrary shell commands, see GHSA-hgx2-4pp9-357g. To
 mitigate this, upgrade the action to a non-vulnerable version.`,
 		extractFrom: func(step *JobStep) string {
 			return step.With["tag"]
@@ -106,9 +106,9 @@ var actionRuleKcebGitMessageAction = actionRule{
 		id:    "ADES201",
 		title: "Expression in 'kceb/git-message-action' sha input",
 		description: `
-When a workflow expression is used in the sha input for 'kceb/git-message-action' in v1.1.0 or
-earlier it may be used to execute arbitrary shell commands (no vulnerability identifier available).
-To mitigate this, upgrade the action to a non-vulnerable version.`,
+When an expression is used in the sha input for 'kceb/git-message-action' in v1.1.0 or earlier it
+may be used to execute arbitrary shell commands (no vulnerability identifier available). To mitigate
+this, upgrade the action to a non-vulnerable version.`,
 		extractFrom: func(step *JobStep) string {
 			return step.With["sha"]
 		},
@@ -126,9 +126,9 @@ var actionRuleRootsIssueCloserIssueCloseMessage = actionRule{
 		id:    "ADES102",
 		title: "Expression in 'roots/issue-closer' issue close message",
 		description: `
-When a workflow expression appears in the issue close message of 'roots/issue-closer' it is
-interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
-expression into an environment variable and using the environment variable instead.
+When an expression appears in the issue close message of 'roots/issue-closer' it is interpreted as
+an ES6-style template literal. You can avoid any potential attacks by extracting the expression into
+an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -162,7 +162,7 @@ var actionRuleRootsIssueCloserPrCloseMessage = actionRule{
 		id:    "ADES103",
 		title: "Expression in 'roots/issue-closer' pull request close message",
 		description: `
-When a workflow expression appears in the pull request close message of 'roots/issue-closer' it is
+When an expression appears in the pull request close message of 'roots/issue-closer' it is
 interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
@@ -198,7 +198,7 @@ var actionRuleSergeysovaJqAction = actionRule{
 		id:    "ADES104",
 		title: "Expression in 'sergeysova/jq-action' command",
 		description: `
-When a workflow expression appears in the command input of 'sergeysova/jq-action' you can avoid any
+When an expression appears in the command input of 'sergeysova/jq-action' you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
 
@@ -255,8 +255,8 @@ var stepRuleRun = stepRule{
 		id:    "ADES100",
 		title: "Expression in 'run:' directive",
 		description: `
-When a workflow expression appears in a 'run:' directive you can avoid any potential attacks by
-extracting the expression into an environment variable and using the environment variable instead.
+When an expression appears in a 'run:' directive you can avoid any potential attacks by extracting
+the expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 

--- a/test/explain.txtar
+++ b/test/explain.txtar
@@ -12,8 +12,8 @@ stderr 'Unknown rule "foobar"'
 -- snapshots/ades100-stdout.txt --
 ADES100 - Expression in 'run:' directive
 
-When a workflow expression appears in a 'run:' directive you can avoid any potential attacks by
-extracting the expression into an environment variable and using the environment variable instead.
+When an expression appears in a 'run:' directive you can avoid any potential attacks by extracting
+the expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 

--- a/web/index.html
+++ b/web/index.html
@@ -44,7 +44,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				<a
 					href="https://docs.github.com/en/actions/learn-github-actions/expressions"
 					rel="noopener"
-				>workflow expression</a>
+				>expressions</a>
 				in it.</p>
 			<textarea
 				class="code"


### PR DESCRIPTION
## Summary

Update wording related to the term "Workflow Expressions" throughout the project to use "GitHub Actions Expressions" or just "Expressions". This is motivated by 1) the fact that the page linked for this term calls it just "Expressions" and 2) expression can be used in action manifest in addition to workflows. The "GitHub Actions" prefix is used in certain cases to be more clear about what kinds of expressions are considered.