### PR TITLE
Support semantic versions without leading "v"

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -287,13 +287,22 @@ var stepRules = []stepRule{
 }
 
 func isBeforeVersion(uses *StepUses, version string) bool {
+	ref := uses.Ref
+	if !strings.HasPrefix(ref, "v") {
+		ref = "v" + ref
+	}
+
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
 	// This comparison checks that the `Ref` is a semantic version string, which is currently the
 	// only supported type of `Ref`.
-	if semver.Canonical(uses.Ref) != uses.Ref {
+	if semver.Canonical(ref) != ref {
 		return false
 	}
 
-	return semver.Compare(version, uses.Ref) > 0
+	return semver.Compare(version, ref) > 0
 }
 
 // Explain returns an explanation for a rule.

--- a/rules_test.go
+++ b/rules_test.go
@@ -635,50 +635,40 @@ func TestFindRule(t *testing.T) {
 func TestIsBeforeVersion(t *testing.T) {
 	type TestCase struct {
 		name    string
-		uses    StepUses
+		ref     string
 		version string
 		want    bool
 	}
 
 	testCases := []TestCase{
 		{
-			name: "Same version, full semantic version",
-			uses: StepUses{
-				Ref: "v1.0.0",
-			},
-			version: "v1.0.0",
+			name:    "Same version, full semantic version",
+			ref:     "1.0.0",
+			version: "1.0.0",
 			want:    false,
 		},
 		{
-			name: "Before, full semantic version",
-			uses: StepUses{
-				Ref: "v0.1.0",
-			},
-			version: "v1.0.0",
+			name:    "Before, full semantic version",
+			ref:     "0.1.0",
+			version: "1.0.0",
 			want:    true,
 		},
 		{
-			name: "After, full semantic version",
-			uses: StepUses{
-				Ref: "v1.0.1",
-			},
-			version: "v1.0.0",
+			name:    "After, full semantic version",
+			ref:     "1.0.1",
+			version: "1.0.0",
 			want:    false,
 		},
 		{
-			name: "SHA",
-			uses: StepUses{
-				Ref: "21fa0360d55070a1d6b999d027db44cc21a7b48d",
-			},
-			version: "v1.0.0",
+			name:    "SHA",
+			ref:     "21fa0360d55070a1d6b999d027db44cc21a7b48d",
+			version: "1.0.0",
 			want:    false,
 		},
 		{
-			name: "Major version only",
-			uses: StepUses{
-				Ref: "v1",
-			},
-			version: "v1.0.0",
+			name:    "Major version only",
+			ref:     "1",
+			version: "1.0.0",
 			want:    false,
 		},
 	}
@@ -687,8 +677,15 @@ func TestIsBeforeVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got, want := isBeforeVersion(&tt.uses, tt.version), tt.want; got != want {
-				t.Errorf("Wrong answer for given %s compared to %s (got %t, want %t)", tt.uses.Ref, tt.version, got, want)
+			variants := make(map[string]string, 2)
+			variants[tt.ref] = tt.version
+			variants["v"+tt.ref] = "v" + tt.version
+
+			for ref, version := range variants {
+				uses := StepUses{Ref: ref}
+				if got, want := isBeforeVersion(&uses, version), tt.want; got != want {
+					t.Errorf("Wrong answer for given %s compared to %s (got %t, want %t)", ref, version, got, want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Contributes to #112

## Summary

Update the implementation of the helper function `isBeforeVersion` to transparently handle version strings and refs without a leading "v". The test suite for `isBeforeVersion` is update to test every case both with and without a leading "v" to ensure consistency between the implementations.