### PR TITLE
Support major version-only refs when checking if a rule applies

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -320,13 +320,15 @@ var stepRules = []stepRule{
 }
 
 func isBeforeVersion(uses *StepUses, version string) bool {
-	// This comparison checks that the `Ref` is a semantic version string, which is currently the
-	// only supported type of `Ref`.
-	if semver.Canonical(uses.Ref) != uses.Ref {
+	if !semver.IsValid(uses.Ref) {
 		return false
 	}
 
-	return semver.Compare(version, uses.Ref) > 0
+	if semver.Canonical(uses.Ref) != uses.Ref {
+		return semver.Compare(uses.Ref, semver.Major(version)) < 0
+	}
+
+	return semver.Compare(uses.Ref, version) < 0
 }
 
 // Explain returns an explanation for a rule.

--- a/rules_test.go
+++ b/rules_test.go
@@ -685,41 +685,89 @@ func TestIsBeforeVersion(t *testing.T) {
 
 	testCases := []TestCase{
 		{
-			name: "Same version, full semantic version",
+			name: "Full version, exact same version",
 			uses: StepUses{
-				Ref: "v1.0.0",
+				Ref: "v1.2.3",
 			},
-			version: "v1.0.0",
+			version: "v1.2.3",
 			want:    false,
 		},
 		{
-			name: "Before, full semantic version",
+			name: "Full version, earlier major version",
 			uses: StepUses{
 				Ref: "v0.1.0",
 			},
-			version: "v1.0.0",
+			version: "v1.2.3",
 			want:    true,
 		},
 		{
-			name: "After, full semantic version",
+			name: "Full version, earlier minor version",
 			uses: StepUses{
-				Ref: "v1.0.1",
+				Ref: "v1.1.0",
 			},
-			version: "v1.0.0",
+			version: "v1.2.3",
+			want:    true,
+		},
+		{
+			name: "Full version, earlier patch version",
+			uses: StepUses{
+				Ref: "v1.2.1",
+			},
+			version: "v1.2.3",
+			want:    true,
+		},
+		{
+			name: "Full version, later major version",
+			uses: StepUses{
+				Ref: "v2.0.0",
+			},
+			version: "v1.2.3",
+			want:    false,
+		},
+		{
+			name: "Full version, later minor version",
+			uses: StepUses{
+				Ref: "v1.3.0",
+			},
+			version: "v1.2.3",
+			want:    false,
+		},
+		{
+			name: "Full version, later patch version",
+			uses: StepUses{
+				Ref: "v1.2.4",
+			},
+			version: "v1.2.3",
+			want:    false,
+		},
+		{
+			name: "Major version only, earlier major version",
+			uses: StepUses{
+				Ref: "v1",
+			},
+			version: "v2.1.0",
+			want:    true,
+		},
+		{
+			name: "Major version only, same major version",
+			uses: StepUses{
+				Ref: "v2",
+			},
+			version: "v2.1.0",
+			want:    false,
+		},
+		{
+			name: "Major version only, later major version",
+			uses: StepUses{
+				Ref: "v3",
+			},
+			version: "v2.1.0",
 			want:    false,
 		},
 		{
 			name: "SHA",
 			uses: StepUses{
 				Ref: "21fa0360d55070a1d6b999d027db44cc21a7b48d",
-			},
-			version: "v1.0.0",
-			want:    false,
-		},
-		{
-			name: "Major version only",
-			uses: StepUses{
-				Ref: "v1",
 			},
 			version: "v1.0.0",
 			want:    false,


### PR DESCRIPTION
Relates to #112 

## Summary

Update the implementation of rules to support comparison against refs consisting only of the major version (e.g. `v4` in `foo/bar@v4`). In particular, the implementation assumes the major version always points to the latest release for said major release, thus if the major version number equals or exceeds to vulnerable version the use is of the action is safe, otherwise it is not.

Crucially, when the major version equals the vulnerable major version this works because of the following: the internals compare against the *patched* version of the action. If the patched version is in the same major version range, allowing use of that major version is OK. If the first patched version is the next major version, than only the next version will be considered unaffected.

This change is tested with one modified and two new test cases ("Major version only, same major version", "Major version only, earlier major version" & "Major version only, later major version" resp.). On top of that, this improves the test suite for the relevant function with more unique test cases of different scenarios when the full semver string is used, in particular when it comes to which of the MAJOR.MINOR.PATCH numbers differs between the `Ref` and comparison version.