### PR TITLE
Create make target for testing reproducible builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -94,16 +94,8 @@ jobs:
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version-file: go.mod
-    - name: Build
-      run: make build
-    - name: Compute checksum
-      run: shasum ades | tee checksums.txt
-    - name: Clear build
-      run: make clean
-    - name: Rebuild
-      run: make build
-    - name: Verify checksum
-      run: shasum --check checksums.txt --strict
+    - name: Check reproducibility
+      run: make reproducible
   test-unit:
     name: Unit test
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,13 @@ release-compile:
 	@echo 'Computing checksums...'
 	@cd _compiled/ && shasum --algorithm 512 ./* >'checksums-sha512.txt'
 
+.PHONY: reproducible
+reproducible:
+	@make build
+	@shasum ades | tee checksums.txt
+	@make clean build
+	@shasum --check checksums.txt --strict
+
 .PHONY: run
 run: ## Run the project on itself
 	@go run ./cmd/ades


### PR DESCRIPTION
Relates to #64

## Summary

Migrate the logic of the reproducible build check from CI to the `Makefile` in order to make it convenient to run the test offline too. The CI now uses this new make target to avoid duplication of the test logic.