### PR TITLE
Upgrade the Ubuntu-based runner used in CI to 24.04

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   capabilities:
     name: Capabilities
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -30,7 +30,7 @@ jobs:
       run: go run tasks.go audit-capabilities
   vulnerabilities:
     name: Vulnerabilities
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -24,7 +24,7 @@ jobs:
       run: go run tasks.go build-all
   compliance:
     name: Compliance
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -38,7 +38,7 @@ jobs:
       run: go run tasks.go compliance
   container:
     name: Container
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +64,7 @@ jobs:
         CONTAINER_ENGINE: ${{ matrix.engine }}
   development-image:
     name: Development image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -76,7 +76,7 @@ jobs:
       run: go run tasks.go dev-img
   format:
     name: Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -90,7 +90,7 @@ jobs:
       run: go run tasks.go format-check
   reproducible:
     name: Reproducible build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -104,7 +104,7 @@ jobs:
       run: go run tasks.go reproducible
   reproducible-container:
     name: Reproducible container
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - container
     - reproducible
@@ -119,7 +119,7 @@ jobs:
       run: go run tasks.go reproducible-container
   reproducible-web:
     name: Reproducible web
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - web
     steps:
@@ -133,7 +133,7 @@ jobs:
       run: go run tasks.go web-reproducible
   test-unit:
     name: Unit test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -147,7 +147,7 @@ jobs:
       run: go run tasks.go test-randomized
   test-dogfeed:
     name: Dogfeed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - test-unit
     steps:
@@ -161,7 +161,7 @@ jobs:
       run: go run tasks.go dogfeed
   test-mutation:
     name: Mutation test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - test-unit
     steps:
@@ -175,7 +175,7 @@ jobs:
       run: go run tasks.go test-mutation
   vet:
     name: Vet
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:
@@ -189,7 +189,7 @@ jobs:
       run: go run tasks.go vet
   web:
     name: Web
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
     - build
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   go:
     name: Go
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write # To upload CodeQL results
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   docker-hub:
     name: Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write # To perform keyless signing with cosign
     environment:
@@ -56,7 +56,7 @@ jobs:
           "docker.io/ericornelissen/ades@${DIGEST}"
   github-release:
     name: GitHub Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       attestations: write # To create GitHub Attestations
       contents: write # To create a GitHub Release

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   semgrep:
     name: Semgrep
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write # To upload SARIF results
     container:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   publish:
     name: Publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Upgrade the Ubuntu-based runner used in CI from 22.04 to 24.04. ~~**NOTE:** As of writing this runner is still in beta, so this should not be merged.~~