### PR TITLE
Setup release artifact attesting with `actions/attest-build-provenance`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,9 @@ jobs:
     name: GitHub Release
     runs-on: ubuntu-22.04
     permissions:
+      attestations: write # To create GitHub Attestations
       contents: write # To create a GitHub Release
+      id-token: write # To perform keyless signing with cosign for attestations
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -80,3 +82,7 @@ jobs:
         name: Release ${{ steps.version.outputs.version }}
         body: ${{ steps.version.outputs.version }}
         artifacts: ./_compiled/*
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      with:
+        subject-path: ./_compiled/*


### PR DESCRIPTION
Relates to #160, #210 

## Summary

Update the "Publish / GitHub Release" job to attest to release artifacts using `actions/attest-build-provenance`. Under the hood, this [also](https://github.com/ericcornelissen/ades/blob/5c618d91eaf908d82806bffe6f4c92f036626c7e/.github/workflows/publish.yml#L21-L24) uses Cosign (<https://docs.sigstore.dev/signing/quickstart/>) with keyless signing based on the workflow's OIDC token.

The attestation functionality is recent (see this [blog post from May 2, 2024](https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/)) and still in beta. I haven't tested this anywhere else, so we'll find out whether and how this works with the next release of this project.