### PR TITLE
Correct name of `build-all` checksums files

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -170,7 +170,7 @@ func TaskBuildAll(t *T) error {
 		return err
 	}
 
-	return os.WriteFile("./_compiled/checksums-shas512.txt", []byte(out), permFile)
+	return os.WriteFile("./_compiled/checksums-sha512.txt", []byte(out), permFile)
 }
 
 // Reset the project to a clean state.


### PR DESCRIPTION
Relates to #147
