### PR TITLE
Add support for comparing to major+minor semver notation (i.e. `vX.Y`)

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -324,11 +324,14 @@ func isBeforeVersion(uses *StepUses, version string) bool {
 		return false
 	}
 
-	if semver.Canonical(uses.Ref) != uses.Ref {
+	switch {
+	case semver.Canonical(uses.Ref) == uses.Ref:
+		return semver.Compare(uses.Ref, version) < 0
+	case semver.MajorMinor(uses.Ref) == uses.Ref:
+		return semver.Compare(uses.Ref, semver.MajorMinor(version)) < 0
+	default:
 		return semver.Compare(uses.Ref, semver.Major(version)) < 0
 	}
-
-	return semver.Compare(uses.Ref, version) < 0
 }
 
 // Explain returns an explanation for a rule.

--- a/rules_test.go
+++ b/rules_test.go
@@ -765,6 +765,78 @@ func TestIsBeforeVersion(t *testing.T) {
 			want:    false,
 		},
 		{
+			name: "Major+minor version, earlier major version and earlier minor version",
+			uses: StepUses{
+				Ref: "v1.1",
+			},
+			version: "v2.2.1",
+			want:    true,
+		},
+		{
+			name: "Major+minor version, earlier major version and same minor version",
+			uses: StepUses{
+				Ref: "v1.2",
+			},
+			version: "v2.2.1",
+			want:    true,
+		},
+		{
+			name: "Major+minor version, earlier major version and later minor version",
+			uses: StepUses{
+				Ref: "v1.3",
+			},
+			version: "v2.2.1",
+			want:    true,
+		},
+		{
+			name: "Major+minor version, same major version and earlier minor version",
+			uses: StepUses{
+				Ref: "v2.1",
+			},
+			version: "v2.2.1",
+			want:    true,
+		},
+		{
+			name: "Major+minor version, same major version and same minor version",
+			uses: StepUses{
+				Ref: "v2.2",
+			},
+			version: "v2.2.1",
+			want:    false,
+		},
+		{
+			name: "Major+minor version, same major version and later minor version",
+			uses: StepUses{
+				Ref: "v2.3",
+			},
+			version: "v2.2.1",
+			want:    false,
+		},
+		{
+			name: "Major+minor version, later major version and earlier minor version",
+			uses: StepUses{
+				Ref: "v3.1",
+			},
+			version: "v2.2.1",
+			want:    false,
+		},
+		{
+			name: "Major+minor version, later major version and same minor version",
+			uses: StepUses{
+				Ref: "v3.2",
+			},
+			version: "v2.2.1",
+			want:    false,
+		},
+		{
+			name: "Major+minor version, later major version and later minor version",
+			uses: StepUses{
+				Ref: "v3.3",
+			},
+			version: "v2.2.1",
+			want:    false,
+		},
+		{
 			name: "SHA",
 			uses: StepUses{
 				Ref: "21fa0360d55070a1d6b999d027db44cc21a7b48d",


### PR DESCRIPTION
Relates to #112, #242

## Summary

Improve the internal logic of rules that look at the version of an Action with support for major+minor semver notation. That is, the version used is specified as vX.Y (instead of vX or vX.Y.Z). I have seen this supported by some Actions which is why I'm adding support for it.

The way this work is mostly straightforward. However, in case the major version and minor version match, the version is considered "not before" the target version because the version range defined by the use of major+minor notation is the latest patch version for vX.Y, which should be unaffected if the major and minor versions are the same between the query and target version.