### PR TITLE
Set expiry date for the Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,9 @@ The maintainers of the `ades` project take security issues seriously. We appreci
 to responsibly disclose your findings. Due to the non-funded and open-source nature of the project,
 we take a best-efforts approach when it comes to engaging with security reports.
 
+This document should be considered expired after 2024-12-31. If you are reading this after that date
+you should try to find an up-to-date version in the official source repository.
+
 ## Supported Versions
 
 Only the latest release of the project is supported with security updates.


### PR DESCRIPTION
## Summary

Include an expiry date in the security policy primarily as a mechanism to ensure the support timeline can reasonable be updated if no end-of-life date has yet been set. Additionally, it nudges anyone looking at the policy to search for an up-to-date version - which is more helpful for anyone.