### PR TITLE
Automate `-version` value

### DIFF
--- a/cmd/ades/main.go
+++ b/cmd/ades/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	_ "embed"
 	"errors"
 	"flag"
 	"fmt"
@@ -430,7 +431,9 @@ Exit Codes:
   2   Problems detected`)
 }
 
+//go:embed version.txt
+var versionString string
+
 func version() {
-	versionString := "v24.06"
 	fmt.Println(versionString)
 }

--- a/test/flags-info.txtar
+++ b/test/flags-info.txtar
@@ -10,7 +10,7 @@ cmp stdout $WORK/snapshots/legal-stdout.txt
 
 # Version
 exec ades -version
-stdout 'v24.06'
+stdout .
 ! stderr .
 
 


### PR DESCRIPTION
## Summary

Update the build procedure for ades to dynamically determine the version based on the VCS information available. The logic is specified in `TaskVersion` but broadly speaking tries to get the version based on a tag (or else related commit information) and if the project is dirty. As a result, the behavior is unchanged if building from a clean commit with a tag, else the commit info and/or dirty state information can help with diagnosing issue (if ades wasn't build from a release tag or with a dirty state, that's a good starting point).