### PR TITLE
Run `go run tasks.go build-all` in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,8 @@ jobs:
         go-version-file: go.mod
     - name: Build binary
       run: go run tasks.go build
+    - name: Build all release binaries
+      run: go run tasks.go build-all
   compliance:
     name: Compliance
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #136

## Summary

Update the "Check / Build" job to, in addition to the regular build command, run the `build-all` command to build all release binaries. This serves both as a check that the command works and that the build still works for all target platforms and architectures.