### PR TITLE
Add support to the `isBeforeVersion` function for SHAs with annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !.editorconfig
 !.gitattributes
 !.gitignore
+!.wrapcheck.yml
 
 # Docs
 !CONTRIBUTING.md

--- a/.wrapcheck.yml
+++ b/.wrapcheck.yml
@@ -1,0 +1,4 @@
+# Check out Wrapcheck at: https://github.com/tomarrell/wrapcheck
+
+ignorePackageGlobs:
+- gopkg.in/yaml.v3

--- a/analyze.go
+++ b/analyze.go
@@ -51,7 +51,7 @@ type Violation struct {
 	stepIndex int
 }
 
-// AnalyzeManifest analyses a GitHub Actions manifest for problematic GitHub Actions Expressions.
+// AnalyzeManifest analyzes a GitHub Actions manifest for problematic GitHub Actions Expressions.
 func AnalyzeManifest(manifest *Manifest, matcher ExprMatcher) []Violation {
 	violations := make([]Violation, 0)
 	if manifest == nil {
@@ -70,7 +70,7 @@ func AnalyzeManifest(manifest *Manifest, matcher ExprMatcher) []Violation {
 	return violations
 }
 
-// AnalyzeWorkflow analyses a GitHub Actions workflow for problematic GitHub Actions Expressions.
+// AnalyzeWorkflow analyzes a GitHub Actions workflow for problematic GitHub Actions Expressions.
 func AnalyzeWorkflow(workflow *Workflow, matcher ExprMatcher) []Violation {
 	violations := make([]Violation, 0)
 	if workflow == nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -122,6 +122,28 @@ jobs:
 					},
 				},
 			},
+			{
+				name: "No names",
+				yaml: `
+jobs:
+  example:
+    steps:
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+`,
+				want: Workflow{
+					Jobs: map[string]WorkflowJob{
+						"example": {
+							Name: "",
+							Steps: []JobStep{
+								{
+									Uses:        "actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b",
+									UsesComment: "v4",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
 		for _, tt := range testCases {
@@ -163,6 +185,10 @@ jobs:
 							t.Errorf("Unexpected uses for job %q step %d (got %q, want %q)", k, i, got, want)
 						}
 
+						if got, want := step.UsesComment, want.UsesComment; got != want {
+							t.Errorf("Unexpected uses comment for job %q step %d (got %q, want %q)", k, i, got, want)
+						}
+
 						if got, want := step.With["script"], want.With["script"]; got != want {
 							t.Errorf("Unexpected with for job %q step %d (got %q, want %q)", k, i, got, want)
 						}
@@ -191,6 +217,15 @@ jobs: 3.14
 jobs:
   example:
     steps: 42
+`,
+			},
+			{
+				name: "Invalid 'env' value",
+				yaml: `
+jobs:
+  example:
+    steps:
+    - env: 1.618
 `,
 			},
 			{
@@ -446,6 +481,18 @@ func TestParseUses(t *testing.T) {
 					Ref:  "7",
 				},
 			},
+			{
+				name: "with comment",
+				step: JobStep{
+					Uses:        "actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b",
+					UsesComment: "v4",
+				},
+				want: StepUses{
+					Name:       "actions/checkout",
+					Ref:        "0ad4b8fadaa221de15dcec353f45205ec38ea70b",
+					Annotation: "v4",
+				},
+			},
 		}
 
 		for _, tt := range testCases {
@@ -463,6 +510,10 @@ func TestParseUses(t *testing.T) {
 
 				if got, want := uses.Ref, tt.want.Ref; got != want {
 					t.Fatalf("Unexpected ref (got %q, want %q)", got, want)
+				}
+
+				if got, want := uses.Annotation, tt.want.Annotation; got != want {
+					t.Fatalf("Unexpected annotation (got %q, want %q)", got, want)
 				}
 			})
 		}

--- a/rules.go
+++ b/rules.go
@@ -320,17 +320,21 @@ var stepRules = []stepRule{
 }
 
 func isBeforeVersion(uses *StepUses, version string) bool {
-	if !semver.IsValid(uses.Ref) {
-		return false
+	ref := uses.Ref
+	if !semver.IsValid(ref) {
+		ref = uses.Annotation
+		if !semver.IsValid(ref) {
+			return false
+		}
 	}
 
 	switch {
-	case semver.Canonical(uses.Ref) == uses.Ref:
-		return semver.Compare(uses.Ref, version) < 0
-	case semver.MajorMinor(uses.Ref) == uses.Ref:
-		return semver.Compare(uses.Ref, semver.MajorMinor(version)) < 0
+	case semver.Canonical(ref) == ref:
+		return semver.Compare(ref, version) < 0
+	case semver.MajorMinor(ref) == ref:
+		return semver.Compare(ref, semver.MajorMinor(version)) < 0
 	default:
-		return semver.Compare(uses.Ref, semver.Major(version)) < 0
+		return semver.Compare(ref, semver.Major(version)) < 0
 	}
 }
 


### PR DESCRIPTION
Relates to #112, #242, #270

## Summary

Improve the rules that depend on the internal `isBeforeVersion` function by adding support for SHA-based refs with comments/annotations to it. It will now, if the ref isn't parsable as a semver string, try to use the comment/annotation (i.e. the comment on the line of the `uses` directive after the value, e.g. `uses: foo@bar # this part`) as a semver string. If it can be parsed as such, it will be used to determine if the version is before the given version. This approach is based on how Dependabot manages versions for SHA-pinned actions - in the future it could be expanded with support for more ways to annotate the version.

### Technical background

To support this change, the workflow/manifest parsing logic had to be updated to record the comment/annotation. As far as I can tell there's no way to achieve this with the `yaml:"something"` syntax so I instead implemented a custom `UnmarshalYAML` function for the `JobStep` struct which manually parses the `yaml.Node` into a `JobStep` and, if the uses value is being parsed, stores the line comment into a special field in the `JobStep` struct.