### PR TITLE
Check reproducibility of the web app build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,6 +117,20 @@ jobs:
         go-version-file: go.mod
     - name: Check reproducibility
       run: go run tasks.go reproducible-container
+  reproducible-web:
+    name: Reproducible web
+    runs-on: ubuntu-22.04
+    needs:
+    - web
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    - name: Install Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      with:
+        go-version-file: go.mod
+    - name: Check reproducibility
+      run: go run tasks.go web-reproducible
   test-unit:
     name: Unit test
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #63

## Summary

Add a third reproducibility task that verifies the build for the website is reproducible. Since `ades.wasm` is the only generated file (others, such as `COPYING.txt` and `wasm_exec.js`, are just copied, and the rest is present statically in the repository) it is the only file that is currently tested.

The reproducibility of the web app is also continuously verified with a new CI job.