### PR TITLE
Upgrade to Go 1.23.0

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-FROM docker.io/golang:1.22.1 AS build
+FROM docker.io/golang:1.23.0 AS build
 
 WORKDIR /src
 

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.22.1-alpine3.19
+FROM docker.io/golang:1.23.0-alpine3.19
 
 RUN apk add --no-cache \
 	bash git npm perl-utils zip \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericcornelissen/ades
 
-go 1.22.1
+go 1.23.0
 
 require (
 	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3


### PR DESCRIPTION
Relates to #159, #322

## Summary

Upgrade from Go 1.22.1 to 1.23.0 to stay up-to-date with the Go language.