### PR TITLE
Prevent XSS through Trusted Types

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <head>
 	<title>ades</title>
 	<meta charset="utf-8" />
+
+	<meta
+		http-equiv="Content-Security-Policy"
+		content="trusted-types 'none'; require-trusted-types-for 'script';"
+	/>
+
 	<link rel="stylesheet" href="index.css">
 	<script src="wasm_exec.js"></script>
 </head>


### PR DESCRIPTION
Relates to #208

## Summary

This enables the new ["Trusted Types"](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) for the ades website to prevent XSS vulnerabilities sneaking in in the future (currently there are no violations so there should be no XSS vulnerabilities).

I tested this change on the code base prior to #208 and it did indeed detect the violation and prevent XSS (by throwing an error).

NOTE: In browsers without support for the Trusted Types API this change has no effect (though it may produce a warning about unknown CSP directives).