### PR TITLE
Expand CSP usage beyond Trusted Types

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -24,7 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	<meta
 		http-equiv="Content-Security-Policy"
-		content="trusted-types 'none'; require-trusted-types-for 'script';"
+		content="base-uri 'none'; connect-src 'self'; default-src 'none'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; trusted-types 'none'; require-trusted-types-for 'script';"
 	/>
 
 	<link rel="stylesheet" href="index.css">


### PR DESCRIPTION
Relates to #350

## Summary

Expand the CSP policy to cover recommended directives, based on <https://csp-evaluator.withgoogle.com/>, and necessary directives.

It seems necessary to have `'wasm-unsafe-eval'` to be able to use WASM. This feels weird because it says `unsafe` but I do not intend to stop using WASM for this website...