### PR TITLE
Improve the output of violations

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -7,8 +7,8 @@ to address it.
 
 ## <a id="ADES100"></a> ADES100 - Expression in `run:` directive
 
-When an expression appears in a `run:` directive you can avoid any potential attacks by extracting
-the expression into an environment variable and using the environment variable instead.
+When an expression appears in a `run:` directive you can avoid potential attacks by extracting the
+expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -34,9 +34,8 @@ it can be made safer by converting it into:
 
 ## <a id="ADES101"></a> ADES101 - Expression in `actions/github-script` script
 
-When an expression appears in a `actions/github-script` script you can avoid any potential attacks
-by extracting the expression into an environment variable and using the environment variable
-instead.
+When an expression appears in a `actions/github-script` script you can avoid potential attacks by
+extracting the expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -65,8 +64,8 @@ it can be made safer by converting it into:
 ## <a id="ADES102"></a> ADES102 - Expression in `roots/issue-closer` issue close message
 
 When an expression appears in the issue close message of `roots/issue-closer` it is interpreted as
-an ES6-style template literal. You can avoid any potential attacks by extracting the expression into
-an environment variable and using the environment variable instead.
+an ES6-style template literal. You can avoid potential attacks by extracting the expression into an
+environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -93,7 +92,7 @@ it can be made safer by converting it into:
 ## <a id="ADES103"></a> ADES103 - Expression in `roots/issue-closer` pull request close message
 
 When an expression appears in the pull request close message of `roots/issue-closer` it is
-interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
+interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:

--- a/rules.go
+++ b/rules.go
@@ -58,9 +58,8 @@ var actionRuleActionsGitHubScript = actionRule{
 		id:    "ADES101",
 		title: "Expression in 'actions/github-script' script",
 		description: `
-When an expression appears in a 'actions/github-script' script you can avoid any potential attacks
-by extracting the expression into an environment variable and using the environment variable
-instead.
+When an expression appears in a 'actions/github-script' script you can avoid potential attacks by
+extracting the expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -137,8 +136,8 @@ var actionRuleRootsIssueCloserIssueCloseMessage = actionRule{
 		title: "Expression in 'roots/issue-closer' issue close message",
 		description: `
 When an expression appears in the issue close message of 'roots/issue-closer' it is interpreted as
-an ES6-style template literal. You can avoid any potential attacks by extracting the expression into
-an environment variable and using the environment variable instead.
+an ES6-style template literal. You can avoid potential attacks by extracting the expression into an
+environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
@@ -196,7 +195,7 @@ var actionRuleRootsIssueCloserPrCloseMessage = actionRule{
 		title: "Expression in 'roots/issue-closer' pull request close message",
 		description: `
 When an expression appears in the pull request close message of 'roots/issue-closer' it is
-interpreted as an ES6-style template literal. You can avoid any potential attacks by extracting the
+interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
@@ -288,8 +287,8 @@ var stepRuleRun = stepRule{
 		id:    "ADES100",
 		title: "Expression in 'run:' directive",
 		description: `
-When an expression appears in a 'run:' directive you can avoid any potential attacks by extracting
-the expression into an environment variable and using the environment variable instead.
+When an expression appears in a 'run:' directive you can avoid potential attacks by extracting the
+expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 

--- a/test/explain.txtar
+++ b/test/explain.txtar
@@ -12,8 +12,8 @@ stderr 'Unknown rule "foobar"'
 -- snapshots/ades100-stdout.txt --
 ADES100 - Expression in 'run:' directive
 
-When an expression appears in a 'run:' directive you can avoid any potential attacks by extracting
-the expression into an environment variable and using the environment variable instead.
+When an expression appears in a 'run:' directive you can avoid potential attacks by extracting the
+expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 

--- a/test/manifest-workflow.txtar
+++ b/test/manifest-workflow.txtar
@@ -52,7 +52,13 @@ jobs:
       run: echo 'Hello ${{ inputs.name }}'
 -- snapshots/yml-stdout.txt --
 Detected 1 violation(s) in ".github/workflows/action.yml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
+  1 in job "Example unsafe job":
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
+
+Use -explain for more details and fix suggestions (example: 'ades -explain ADES100')
 -- snapshots/yaml-stdout.txt --
 Detected 1 violation(s) in ".github/workflows/action.yaml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
+  1 in job "Example unsafe job":
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
+
+Use -explain for more details and fix suggestions (example: 'ades -explain ADES100')

--- a/test/stdout.txtar
+++ b/test/stdout.txtar
@@ -36,8 +36,7 @@ cmp stdout $WORK/snapshots/stdin-stdout.txt
 
 # Suggestions
 ! exec ades -suggestions 'project/.github/workflows/workflow.yml'
-cmp stdout $WORK/snapshots/suggestion-stdout.txt
-! stderr .
+cmp stderr $WORK/snapshots/suggestion-stdout.txt
 
 # Not found
 ! exec ades 'does-not-exist'
@@ -95,31 +94,35 @@ jobs:
 {"problems":[{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe run","problem":"${{ inputs.name }}"},{"target":"project/","file":".github/workflows/workflow.yml","job":"Example unsafe job","step":"Unsafe GitHub script","problem":"${{ inputs.name }}"},{"target":"project/","file":"action.yml","job":"","step":"Unsafe run","problem":"${{ inputs.name }}"}]}
 -- snapshots/manifest-stdout.txt --
 Detected 1 violation(s) in "project/action.yml":
-  step "Unsafe run" has "${{ inputs.name }}" (ADES100)
--- snapshots/multiple-stdout.txt --
-[project/action.yml]
-Detected 1 violation(s) in "project/action.yml":
-  step "Unsafe run" has "${{ inputs.name }}" (ADES100)
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
 
+Use -explain for more details and fix suggestions (example: 'ades -explain ADES100')
+-- snapshots/multiple-stdout.txt --
 [project/.github/workflows/workflow.yml]
 Detected 2 violation(s) in "project/.github/workflows/workflow.yml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
-  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}" (ADES101)
+  2 in job "Example unsafe job":
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
+    step "Unsafe GitHub script" contains "${{ inputs.name }}" (ADES101)
+
+[project/action.yml]
+Detected 1 violation(s) in "project/action.yml":
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
+
+Use -explain for more details and fix suggestions (example: 'ades -explain ADES100')
 -- snapshots/stdin-stdout.txt --
 Detected 2 violation(s) in "stdin":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
-  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}" (ADES101)
+  2 in job "Example unsafe job":
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
+    step "Unsafe GitHub script" contains "${{ inputs.name }}" (ADES101)
+
+Use -explain for more details and fix suggestions (example: 'ades -explain ADES100')
 -- snapshots/suggestion-stdout.txt --
-Detected 2 violation(s) in "project/.github/workflows/workflow.yml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `$NAME`
-       (make sure to keep the behavior of the script the same)
-  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}", suggestion:
-    1. Set `NAME: ${{ inputs.name }}` in the step's `env` map
-    2. Replace all occurrences of `${{ inputs.name }}` by `process.env.NAME`
-       (make sure to keep the behavior of the script the same)
+The -suggestions flag is deprecated and will be removed in the future
+
 -- snapshots/workflow-stdout.txt --
 Detected 2 violation(s) in "project/.github/workflows/workflow.yml":
-  job "Example unsafe job", step "Unsafe run" has "${{ inputs.name }}" (ADES100)
-  job "Example unsafe job", step "Unsafe GitHub script" has "${{ inputs.name }}" (ADES101)
+  2 in job "Example unsafe job":
+    step "Unsafe run" contains "${{ inputs.name }}" (ADES100)
+    step "Unsafe GitHub script" contains "${{ inputs.name }}" (ADES101)
+
+Use -explain for more details and fix suggestions (example: 'ades -explain ADES100')


### PR DESCRIPTION
Relates to #3, #36, #93

## Summary

This improves upon the output of violations. It does so in a couple of ways. First it removes the inline suggestions - which become clutter for many results - in favor of recommending the use of `ades -explain` at the end of the human-readable report (also resolving the no-op of the `-suggestions` flag when `-json` is used). Second, it now groups the violations by the job in which they occur, reducing the amount of duplicated text in the output.

When this is merged, an issue should be created to remove the `-suggestions` flag at some point in the future.
