### PR TITLE
Replace the Python-based http server by a Go-based http server

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -20,7 +20,7 @@
 FROM docker.io/golang:1.23.0-alpine3.19
 
 RUN apk add --no-cache \
-	bash git perl-utils python3 zip \
+	bash git perl-utils zip \
 	&& \
 	echo "alias gask='go run tasks.go'" >~/.bashrc \
 	&& \

--- a/tasks.go
+++ b/tasks.go
@@ -30,6 +30,7 @@ import (
 	"go/token"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
@@ -623,8 +624,8 @@ func TaskWebServe(t *T) error {
 	}
 
 	t.Log("Serving locally...")
-	t.Cd(webDir)
-	return t.Exec("python3 -m http.server 8080")
+	http.Handle("/", http.FileServer(http.Dir("web")))
+	return http.ListenAndServe(":8080", nil)
 }
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Relates to #361, https://github.com/ericcornelissen/ades/pull/393#discussion_r1884638818

## Summary

Remove the dependency on Python in favor of just using Go's standard library http server to serve the web app for local development purposes.