### PR TITLE
Filter out expressions that are certainly safe

### DIFF
--- a/matchers_test.go
+++ b/matchers_test.go
@@ -16,6 +16,7 @@
 package ades
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -27,70 +28,104 @@ func TestAllMatcher(t *testing.T) {
 	}
 
 	testCases := map[string]TestCase{
-		"arbitrary expression ": {
-			value: "${{ foo.bar }}",
+		"not an expression": {
+			value: `'Hello world'`,
+			want:  nil,
+		},
+		"safe expression": {
+			value: `${{ true }}`,
+			want:  nil,
+		},
+		"safe use of an unsafe expression": {
+			value: `${{ contains(github.event.issue.title, 'foobar') }}`,
+			want:  nil,
+		},
+		"unsafe expression ": {
+			value: `${{ foo.bar }}`,
 			want: []string{
-				"${{ foo.bar }}",
+				`${{ foo.bar }}`,
 			},
 		},
 		"input expression": {
-			value: "${{ input.greeting }}",
+			value: `${{ input.greeting }}`,
 			want: []string{
-				"${{ input.greeting }}",
+				`${{ input.greeting }}`,
 			},
 		},
 		"matrix expression": {
-			value: "${{ matrix.runtime }}",
+			value: `${{ matrix.runtime }}`,
 			want: []string{
-				"${{ matrix.runtime }}",
+				`${{ matrix.runtime }}`,
 			},
 		},
 		"vars expression": {
-			value: "${{ vars.command }}",
+			value: `${{ vars.command }}`,
 			want: []string{
-				"${{ vars.command }}",
+				`${{ vars.command }}`,
 			},
 		},
 		"secrets expression": {
-			value: "${{ secrets.value }}",
+			value: `${{ secrets.value }}`,
 			want: []string{
-				"${{ secrets.value }}",
+				`${{ secrets.value }}`,
 			},
 		},
 		"github.event.issue.title": {
-			value: "${{ github.event.issue.title }}",
+			value: `${{ github.event.issue.title }}`,
 			want: []string{
-				"${{ github.event.issue.title }}",
+				`${{ github.event.issue.title }}`,
 			},
 		},
 		"github.event.discussion.body": {
-			value: "${{ github.event.discussion.body }}",
+			value: `${{ github.event.discussion.body }}`,
 			want: []string{
-				"${{ github.event.discussion.body }}",
+				`${{ github.event.discussion.body }}`,
 			},
 		},
 		"github.event.pages[*].page_name": {
-			value: "${{ github.event.pages[0].page_name }}",
+			value: `${{ github.event.pages[0].page_name }}`,
 			want: []string{
-				"${{ github.event.pages[0].page_name }}",
+				`${{ github.event.pages[0].page_name }}`,
 			},
 		},
 		"github.event.commits[*].author.email": {
-			value: "${{ github.event.commits[1].author.email }}",
+			value: `${{ github.event.commits[1].author.email }}`,
 			want: []string{
-				"${{ github.event.commits[1].author.email }}",
+				`${{ github.event.commits[1].author.email }}`,
 			},
 		},
 		"github.head_ref": {
-			value: "${{ github.head_ref }}",
+			value: `${{ github.head_ref }}`,
 			want: []string{
-				"${{ github.head_ref }}",
+				`${{ github.head_ref }}`,
 			},
 		},
 		"github.event.workflow_run.pull_requests[*].head.ref": {
-			value: "${{ github.event.workflow_run.pull_requests[2].head.ref }}",
+			value: `${{ github.event.workflow_run.pull_requests[2].head.ref }}`,
 			want: []string{
-				"${{ github.event.workflow_run.pull_requests[2].head.ref }}",
+				`${{ github.event.workflow_run.pull_requests[2].head.ref }}`,
+			},
+		},
+		"safe & unsafe in one expression": {
+			value: `${{ foo.bar || true }}`,
+			want: []string{
+				`${{ foo.bar || true }}`,
+			},
+		},
+		"unsafe & safe in one expression": {
+			value: `${{ false || foo.baz }}`,
+			want: []string{
+				`${{ false || foo.baz }}`,
+			},
+		},
+		"safe & safe in one expression": {
+			value: `echo ${{ false || true }}`,
+			want:  nil,
+		},
+		"unsafe & unsafe in one expression": {
+			value: `${{ foo.bar || foo.baz }}`,
+			want: []string{
+				`${{ foo.bar || foo.baz }}`,
 			},
 		},
 	}
@@ -122,178 +157,204 @@ func TestConservativeMatcher(t *testing.T) {
 	}
 
 	testCases := map[string]TestCase{
+		"not an expression": {
+			value: `'Hello world'`,
+			want:  nil,
+		},
+		"safe expression": {
+			value: `${{ true }}`,
+			want:  nil,
+		},
+		"conservatively safe expression": {
+			value: `${{ input.greeting }}`,
+			want:  nil,
+		},
+		"safe use of conservatively unsafe expression": {
+			value: `${{ contains(github.event.issue.title, 'foobar') }}`,
+			want:  nil,
+		},
 		"github.event.issue.title": {
-			value: "${{ github.event.issue.title }}",
+			value: `${{ github.event.issue.title }}`,
 			want: []string{
-				"${{ github.event.issue.title }}",
+				`${{ github.event.issue.title }}`,
 			},
 		},
 		"github.event.issue.body": {
-			value: "${{ github.event.issue.body }}",
+			value: `${{ github.event.issue.body }}`,
 			want: []string{
-				"${{ github.event.issue.body }}",
+				`${{ github.event.issue.body }}`,
 			},
 		},
 		"github.event.discussion.title": {
-			value: "${{ github.event.discussion.title }}",
+			value: `${{ github.event.discussion.title }}`,
 			want: []string{
-				"${{ github.event.discussion.title }}",
+				`${{ github.event.discussion.title }}`,
 			},
 		},
 		"github.event.discussion.body": {
-			value: "${{ github.event.discussion.body }}",
+			value: `${{ github.event.discussion.body }}`,
 			want: []string{
-				"${{ github.event.discussion.body }}",
+				`${{ github.event.discussion.body }}`,
 			},
 		},
 		"github.event.comment.body": {
-			value: "${{ github.event.comment.body }}",
+			value: `${{ github.event.comment.body }}`,
 			want: []string{
-				"${{ github.event.comment.body }}",
+				`${{ github.event.comment.body }}`,
 			},
 		},
 		"github.event.review.body": {
-			value: "${{ github.event.review.body }}",
+			value: `${{ github.event.review.body }}`,
 			want: []string{
-				"${{ github.event.review.body }}",
+				`${{ github.event.review.body }}`,
 			},
 		},
 		"github.event.review_comment.body": {
-			value: "${{ github.event.review_comment.body }}",
+			value: `${{ github.event.review_comment.body }}`,
 			want: []string{
-				"${{ github.event.review_comment.body }}",
+				`${{ github.event.review_comment.body }}`,
 			},
 		},
 		"github.event.pages[*].page_name": {
-			value: "${{ github.event.pages[0].page_name }}",
+			value: `${{ github.event.pages[0].page_name }}`,
 			want: []string{
-				"${{ github.event.pages[0].page_name }}",
+				`${{ github.event.pages[0].page_name }}`,
 			},
 		},
 		"github.event.commits[*].message": {
-			value: "${{ github.event.commits[1].message }}",
+			value: `${{ github.event.commits[1].message }}`,
 			want: []string{
-				"${{ github.event.commits[1].message }}",
+				`${{ github.event.commits[1].message }}`,
 			},
 		},
 		"github.event.commits[*].author.email": {
-			value: "${{ github.event.commits[2].author.email }}",
+			value: `${{ github.event.commits[2].author.email }}`,
 			want: []string{
-				"${{ github.event.commits[2].author.email }}",
+				`${{ github.event.commits[2].author.email }}`,
 			},
 		},
 		"github.event.commits[*].author.name": {
-			value: "${{ github.event.commits[3].author.name }}",
+			value: `${{ github.event.commits[3].author.name }}`,
 			want: []string{
-				"${{ github.event.commits[3].author.name }}",
+				`${{ github.event.commits[3].author.name }}`,
 			},
 		},
 		"github.event.head_commit.message": {
-			value: "${{ github.event.head_commit.message }}",
+			value: `${{ github.event.head_commit.message }}`,
 			want: []string{
-				"${{ github.event.head_commit.message }}",
+				`${{ github.event.head_commit.message }}`,
 			},
 		},
 		"github.event.head_commit.author.email": {
-			value: "${{ github.event.head_commit.author.email }}",
+			value: `${{ github.event.head_commit.author.email }}`,
 			want: []string{
-				"${{ github.event.head_commit.author.email }}",
+				`${{ github.event.head_commit.author.email }}`,
 			},
 		},
 		"github.event.head_commit.author.name": {
-			value: "${{ github.event.head_commit.author.name }}",
+			value: `${{ github.event.head_commit.author.name }}`,
 			want: []string{
-				"${{ github.event.head_commit.author.name }}",
+				`${{ github.event.head_commit.author.name }}`,
 			},
 		},
 		"github.event.head_commit.committer.email": {
-			value: "${{ github.event.head_commit.committer.email }}",
+			value: `${{ github.event.head_commit.committer.email }}`,
 			want: []string{
-				"${{ github.event.head_commit.committer.email }}",
+				`${{ github.event.head_commit.committer.email }}`,
 			},
 		},
 		"github.event.workflow_run.head_branch": {
-			value: "${{ github.event.workflow_run.head_branch }}",
+			value: `${{ github.event.workflow_run.head_branch }}`,
 			want: []string{
-				"${{ github.event.workflow_run.head_branch }}",
+				`${{ github.event.workflow_run.head_branch }}`,
 			},
 		},
 		"github.event.workflow_run.head_commit.message": {
-			value: "${{ github.event.workflow_run.head_commit.message }}",
+			value: `${{ github.event.workflow_run.head_commit.message }}`,
 			want: []string{
-				"${{ github.event.workflow_run.head_commit.message }}",
+				`${{ github.event.workflow_run.head_commit.message }}`,
 			},
 		},
 		"github.event.workflow_run.head_commit.author.email": {
-			value: "${{ github.event.workflow_run.head_commit.author.email }}",
+			value: `${{ github.event.workflow_run.head_commit.author.email }}`,
 			want: []string{
-				"${{ github.event.workflow_run.head_commit.author.email }}",
+				`${{ github.event.workflow_run.head_commit.author.email }}`,
 			},
 		},
 		"github.event.workflow_run.head_commit.author.name": {
-			value: "${{ github.event.workflow_run.head_commit.author.name }}",
+			value: `${{ github.event.workflow_run.head_commit.author.name }}`,
 			want: []string{
-				"${{ github.event.workflow_run.head_commit.author.name }}",
+				`${{ github.event.workflow_run.head_commit.author.name }}`,
 			},
 		},
 		"github.event.pull_request.title": {
-			value: "${{ github.event.pull_request.title }}",
+			value: `${{ github.event.pull_request.title }}`,
 			want: []string{
-				"${{ github.event.pull_request.title }}",
+				`${{ github.event.pull_request.title }}`,
 			},
 		},
 		"github.event.pull_request.body": {
-			value: "${{ github.event.pull_request.body }}",
+			value: `${{ github.event.pull_request.body }}`,
 			want: []string{
-				"${{ github.event.pull_request.body }}",
+				`${{ github.event.pull_request.body }}`,
 			},
 		},
 		"github.event.pull_request.head.label": {
-			value: "${{ github.event.pull_request.head.label }}",
+			value: `${{ github.event.pull_request.head.label }}`,
 			want: []string{
-				"${{ github.event.pull_request.head.label }}",
+				`${{ github.event.pull_request.head.label }}`,
 			},
 		},
 		"github.event.pull_request.head.repo.default_branch": {
-			value: "${{ github.event.pull_request.head.repo.default_branch }}",
+			value: `${{ github.event.pull_request.head.repo.default_branch }}`,
 			want: []string{
-				"${{ github.event.pull_request.head.repo.default_branch }}",
+				`${{ github.event.pull_request.head.repo.default_branch }}`,
 			},
 		},
 		"github.head_ref": {
-			value: "${{ github.head_ref }}",
+			value: `${{ github.head_ref }}`,
 			want: []string{
-				"${{ github.head_ref }}",
+				`${{ github.head_ref }}`,
 			},
 		},
 		"github.event.pull_request.head.ref": {
-			value: "${{ github.event.pull_request.head.ref }}",
+			value: `${{ github.event.pull_request.head.ref }}`,
 			want: []string{
-				"${{ github.event.pull_request.head.ref }}",
+				`${{ github.event.pull_request.head.ref }}`,
 			},
 		},
 		"github.event.workflow_run.pull_requests[*].head.ref": {
-			value: "${{ github.event.workflow_run.pull_requests[4].head.ref }}",
+			value: `${{ github.event.workflow_run.pull_requests[4].head.ref }}`,
 			want: []string{
-				"${{ github.event.workflow_run.pull_requests[4].head.ref }}",
+				`${{ github.event.workflow_run.pull_requests[4].head.ref }}`,
 			},
 		},
-		"two, both are dangerous": {
-			value: "${{ github.event.pull_request.head.ref || github.head_ref }}",
+
+		"(conservatively) safe & unsafe in one expression": {
+			value: `${{ foo.bar || github.head_ref }}`,
 			want: []string{
-				"${{ github.event.pull_request.head.ref || github.head_ref }}",
+				`${{ foo.bar || github.head_ref }}`,
 			},
 		},
-		"two, only one is dangerous": {
-			value: "${{ github.event.pull_request.head.ref || inputs.backup }}",
+		"unsafe & (conservatively) safe in one expression": {
+			value: `${{ github.event.pull_request.head.ref || inputs.backup }}`,
 			want: []string{
-				"${{ github.event.pull_request.head.ref || inputs.backup }}",
+				`${{ github.event.pull_request.head.ref || inputs.backup }}`,
 			},
 		},
-		"not conservatively dangerous": {
-			value: "${{ input.greeting }}",
-			want:  []string{},
+		"(conservatively) safe & (conservatively) safe in one expression": {
+			value: `echo ${{ foo.bar || inputs.backup }}`,
+			want:  nil,
 		},
+		"unsafe & unsafe in one expression": {
+			value: `${{ github.event.pull_request.head.ref || github.head_ref }}`,
+			want: []string{
+				`${{ github.event.pull_request.head.ref || github.head_ref }}`,
+			},
+		},
+
+		"unsafe and unsafe in one expression": {},
+		"two, only one is dangerous":          {},
 	}
 
 	for name, tt := range testCases {
@@ -311,6 +372,179 @@ func TestConservativeMatcher(t *testing.T) {
 				if got, want := string(match), tt.want[i]; got != want {
 					t.Errorf("Unexpected #%d violation (got %q, want %q)", i, got, want)
 				}
+			}
+		})
+	}
+}
+
+func TestDefinitelySafe(t *testing.T) {
+	type TestCase struct {
+		value string
+		want  string
+	}
+
+	testCases := map[string]TestCase{
+		"literal, boolean, true": {
+			value: `echo ${{ true }}`,
+			want:  `echo `,
+		},
+		"literal, boolean, false": {
+			value: `echo ${{ false }}`,
+			want:  `echo `,
+		},
+		"literal, null": {
+			value: `echo ${{ null }}`,
+			want:  `echo `,
+		},
+		"literal, number, positive integer": {
+			value: `echo ${{ 42 }}`,
+			want:  `echo `,
+		},
+		"literal, number, negative integer": {
+			value: `echo ${{ -36 }}`,
+			want:  `echo `,
+		},
+		"literal, number, float": {
+			value: `echo ${{ 3.14 }}`,
+			want:  `echo `,
+		},
+		"literal, number, hexadecimal (uppercase)": {
+			value: `echo ${{ 0x2A }}`,
+			want:  `echo `,
+		},
+		"literal, number, hexadecimal (lowercase)": {
+			value: `echo ${{ 0x2a }}`,
+			want:  `echo `,
+		},
+		"literal, number, hexadecimal (mixed case)": {
+			value: `echo ${{ 0xDeAdBeEf }}`,
+			want:  `echo `,
+		},
+		"literal, number, scientific notation, positive, small": {
+			value: `echo ${{ 2.99e-2 }}`,
+			want:  `echo `,
+		},
+		"literal, number, scientific notation, positive, big": {
+			value: `echo ${{ 2.99e2 }}`,
+			want:  `echo `,
+		},
+		"literal, number, scientific notation, negative, small": {
+			value: `echo ${{ -2.99e-2 }}`,
+			want:  `echo `,
+		},
+		"literal, number, scientific notation, negative, big": {
+			value: `echo ${{ -2.99e2 }}`,
+			want:  `echo `,
+		},
+		"literal, string": {
+			value: `echo ${{ 'Hello world' }}`,
+			want:  `echo `,
+		},
+		"literal, multiple": {
+			value: `echo ${{ true || 42 }}`,
+			want:  `echo `,
+		},
+		"function, always": {
+			value: `echo ${{ always() }}`,
+			want:  `echo `,
+		},
+		"function, cancelled": {
+			value: `echo 'The job was cancelled: ${{ cancelled() }}'`,
+			want:  `echo 'The job was cancelled: '`,
+		},
+		"function, contains, no variables": {
+			value: `echo 'Does the string contain llo: ${{ contains('Hello world', 'llo') }}'`,
+			want:  `echo 'Does the string contain llo: '`,
+		},
+		"function, contains, with variables": {
+			value: `echo 'Does ${{ inputs.greeting }} contain llo: ${{ contains(inputs.greeting, 'llo') }}'`,
+			want:  `echo 'Does ${{ inputs.greeting }} contain llo: '`,
+		},
+		"function, endsWith, no variables": {
+			value: `echo 'Does the string end with llo: ${{ endsWith('Hello world', 'llo') }}'`,
+			want:  `echo 'Does the string end with llo: '`,
+		},
+		"function, endsWith, with variables": {
+			value: `echo 'Does ${{ inputs.greeting }} end with llo: ${{ endsWith(inputs.greeting, 'llo') }}'`,
+			want:  `echo 'Does ${{ inputs.greeting }} end with llo: '`,
+		},
+		"function, failure": {
+			value: `echo 'The job failed: ${{ failure() }}'`,
+			want:  `echo 'The job failed: '`,
+		},
+		"function, format, no variables": {
+			value: `echo ${{ format('Hello {0}', 'world') }}`,
+			want:  `echo `,
+		},
+		"function, format, with variables": {
+			value: `echo ${{ format('Hello {0}', inputs.who) }}`,
+			want:  `echo ${{ format(, inputs.who) }}`,
+		},
+		"function, fromJSON, no variables": {
+			value: `obj=${{ fromJSON('["foo", "bar"]') }}`,
+			want:  `obj=`,
+		},
+		"function, fromJSON, with variables": {
+			value: `obj=${{ fromJSON(inputs.json) }}`,
+			want:  `obj=${{ fromJSON(inputs.json) }}`,
+		},
+		"function, hashFiles, no variables": {
+			value: `echo 'hash: ${{ hashFiles('**/*.go') }}'`,
+			want:  `echo 'hash: '`,
+		},
+		"function, hashFiles, with variables": {
+			value: `echo 'hash: ${{ hashFiles(input.files) }}'`,
+			want:  `echo 'hash: '`,
+		},
+		"function, join, no variables": {
+			value: `echo 'The elements are: ${{ join(fromJSON('["foo", "bar"]'), ', ') }}'`,
+			want:  `echo 'The elements are: '`,
+		},
+		"function, join, with variables": {
+			value: `echo 'The elements are: ${{ join(inputs.list, ', ') }}'`,
+			want:  `echo 'The elements are: ${{ join(inputs.list, ) }}'`,
+		},
+		"function, startsWith, no variables": {
+			value: `echo 'Does the string start with llo: ${{ startsWith('Hello world', 'llo') }}'`,
+			want:  `echo 'Does the string start with llo: '`,
+		},
+		"function, startsWith, with variables": {
+			value: `echo 'Does ${{ inputs.greeting }} start with llo: ${{ startsWith(inputs.greeting, 'llo') }}'`,
+			want:  `echo 'Does ${{ inputs.greeting }} start with llo: '`,
+		},
+		"function, success": {
+			value: `echo 'The job succeeded: ${{ success() }}'`,
+			want:  `echo 'The job succeeded: '`,
+		},
+		"function, toJSON, with variables": {
+			value: `json=${{ toJSON(inputs.value) }}`,
+			want:  `json=${{ toJSON(inputs.value) }}`,
+		},
+		"edge case, literals with odd spacing": {
+			value: `echo ${{true}}${{false }}${{ null}}${{ (0x2A) }}${{ false||1 }}${{ true&&0 }}${{ 0==false }}${{ 4!=2 }}${{ 3>14 }}${{ 14>=3 }}${{ 2<718 }}${{ 718<=2 }}${{ !true }}`,
+			want:  `echo `,
+		},
+		"edge case, functions with odd spacing": {
+			value: `echo ${{success( )}}${{failure() }}${{ always()}}${{ (cancelled()) }}${{ startsWith('foobar', 'foo')&&endsWith('foobar', 'bar') }}${{ startsWith('foobar', 'foo')||endsWith('foobar', 'baz') }}`,
+			want:  `echo `,
+		},
+		"edge case, identifier like a literal": {
+			value: `echo ${{ trueish }}`,
+			want:  `echo ${{ trueish }}`,
+		},
+		"edge case, identifier like a function": {
+			value: `echo ${{ contained('foo', 'bar') }}`,
+			want:  `echo ${{ contained(, ) }}`,
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := []byte(tt.value)
+			if got, want := stripSafe(v), []byte(tt.want); !bytes.Equal(got, want) {
+				t.Errorf("Unexpected result (got %q, want %q)", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Relates to #366

## Summary

Update the expressions matcher logic to not complain about expressions that can be proven to be safe because they consist exclusively of [literals](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals) and/or [functions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#functions) whose output does not contain any of the input values (i.e. all predicate functions as well as `hashFiles`).

The choice to match twice, once against the input with safe expressions removed and once against the actual input, may seem unnecessarily bad from a performance point of view. However, if the stripped input does contain a problem, we want to get the matches on the original input to present to the user. The performance impact is minimized by using the `Regexp.Find` method which will return on the first match.

What is implemented here is what is suggested in the first comment of #366. This is because I'm more comfortable *always* allowing these since they're 100% safe because their output is in a fixed domain, while e.g. `${{ matrix.xyz }}` is still an arbitrary value...