### PR TITLE
Enable Docker updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@
 
 version: 2
 updates:
+- package-ecosystem: docker
+  directory: /
+  open-pull-requests-limit: 1
+  schedule:
+    interval: daily
+    time: "04:00"
+  labels:
+  - dependencies
 - package-ecosystem: gomod
   directory: /
   open-pull-requests-limit: 1


### PR DESCRIPTION
Relates to #123

Open questions:

- It's not entirely obvious this is desirable as the [Go version in the `Containerfile`](https://github.com/ericcornelissen/ades/blob/e88d920ed9ec8a862189fef58693f23744e2bcf2/Containerfile#L16C23-L16C29) should always be the same as the [Go version in `go.mod`](https://github.com/ericcornelissen/ades/blob/e88d920ed9ec8a862189fef58693f23744e2bcf2/go.mod#L3C4-L3C10). I guess this automation at least lets us know when a new Go version is available.
- At this point I'm unsure how to enable updates for `Containerfile.dev`.