### PR TITLE
Synchronize local Go version with container images Go version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024  Eric Cornelissen
+# Copyright (C) 2023-2025  Eric Cornelissen
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,7 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-FROM docker.io/golang:1.23.0 AS build
+ARG GO_VERSION=invalid
+FROM docker.io/golang:${GO_VERSION} AS build
 
 WORKDIR /src
 

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,6 +1,6 @@
 # MIT No Attribution
 #
-# Copyright (c) 2023-2024 Eric Cornelissen
+# Copyright (c) 2023-2025 Eric Cornelissen
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -17,7 +17,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM docker.io/golang:1.23.0-alpine3.19
+ARG GO_VERSION=invalid
+FROM docker.io/golang:${GO_VERSION}-alpine3.19
 
 RUN apk add --no-cache \
 	bash git perl-utils zip \


### PR DESCRIPTION
Relates to #81, #119, #123, #413

## Summary

Update the `Containerfile`s to accept a Go version as build argument and use it for the base image. The version must be specified at build time (otherwise the default value "invalid" causes the build to fail) which is done by the relevant tasks defined in `tasks.go`. These tasks use the `runtime` package's Version function to determine the current Go version and specify it as a build argument when building container images.