### PR TITLE
Add rule for dangerous expression in `run:` with Python

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -147,6 +147,35 @@ it can be made safer by converting it into:
   #                   | Replace the expression with the environment variable
 ```
 
+## <a id="ADES105"></a> ADES105 - Expression in `run:` directive with Python
+
+When an expression appears in a 'run:' directive you can avoid potential attacks by extracting the
+expression into an environment variable and using the environment variable instead.
+
+For example, given the workflow snippet:
+
+```yaml
+- name: Example step
+  shell: python
+  run: |
+    print('Hello ${{ inputs.name }}')
+```
+
+it can be made safer by converting it into:
+
+```yaml
+- name: Example step
+  shell: python
+  env:
+    NAME: ${{ inputs.name }} # <- Assign the expression to an environment variable
+  run: |
+    print(f'Hello {os.getenv("HOME")}')
+  #       ^        ^^^^^^^^^^^^^^^^^
+  #       |        | Replace the expression with the environment variable
+  #       |
+  #       | Note: the use of the literal prefix 'f' is required for interpolation
+```
+
 ## <a id="ADES200"></a> ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
 
 When an expression is used in the tag input for `ericcornelissen/git-tag-annotation-action` in

--- a/parse.go
+++ b/parse.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024  Eric Cornelissen
+// Copyright (C) 2023-2025  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ type JobStep struct {
 	Env         map[string]string `yaml:"env"`
 	Name        string            `yaml:"name"`
 	Run         string            `yaml:"run"`
+	Shell       string            `yaml:"shell"`
 	Uses        string            `yaml:"uses"`
 	UsesComment string            `yaml:"-"`
 }
@@ -61,6 +62,8 @@ func (step *JobStep) UnmarshalYAML(node *yaml.Node) error {
 			step.Name = value.Value
 		case "run":
 			step.Run = value.Value
+		case "shell":
+			step.Shell = value.Value
 		case "uses":
 			step.Uses = value.Value
 			step.UsesComment = strings.TrimLeft(value.LineComment, "# ")

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024  Eric Cornelissen
+// Copyright (C) 2023-2025  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -37,6 +37,9 @@ jobs:
         fetch-depth: 1
     - name: Echo value
       run: echo '${{ inputs.value }}'
+    - name: Echo value in PowerShell
+      shell: pwsh
+      run: echo 'PowerShell ${{ inputs.value }}'
 `,
 				want: Workflow{
 					Jobs: map[string]WorkflowJob{
@@ -50,6 +53,11 @@ jobs:
 								{
 									Name: "Echo value",
 									Run:  "echo '${{ inputs.value }}'",
+								},
+								{
+									Name:  "Echo value in PowerShell",
+									Run:   "echo 'PowerShell ${{ inputs.value }}'",
+									Shell: "pwsh",
 								},
 							},
 						},
@@ -176,6 +184,10 @@ jobs:
 							t.Errorf("Unexpected run for job %q step %d (got %q, want %q)", k, i, got, want)
 						}
 
+						if got, want := step.Shell, want.Shell; got != want {
+							t.Errorf("Unexpected shell for step %d (got %q, want %q)", i, got, want)
+						}
+
 						if got, want := step.Uses, want.Uses; got != want {
 							t.Errorf("Unexpected uses for job %q step %d (got %q, want %q)", k, i, got, want)
 						}
@@ -273,6 +285,9 @@ runs:
       fetch-depth: 1
   - name: Echo value
     run: echo '${{ inputs.value }}'
+  - name: Echo value in PowerShell
+    shell: pwsh
+    run: echo 'PowerShell ${{ inputs.value }}'
 `,
 				want: Manifest{
 					Runs: ManifestRuns{
@@ -285,6 +300,11 @@ runs:
 							{
 								Name: "Echo value",
 								Run:  "echo '${{ inputs.value }}'",
+							},
+							{
+								Name:  "Echo value in PowerShell",
+								Run:   "echo 'PowerShell ${{ inputs.value }}'",
+								Shell: "pwsh",
 							},
 						},
 					},
@@ -351,6 +371,10 @@ runs:
 
 					if got, want := step.Run, want.Run; got != want {
 						t.Errorf("Unexpected run for step %d (got %q, want %q)", i, got, want)
+					}
+
+					if got, want := step.Shell, want.Shell; got != want {
+						t.Errorf("Unexpected shell for step %d (got %q, want %q)", i, got, want)
 					}
 
 					if got, want := step.Uses, want.Uses; got != want {

--- a/test/rules.txtar
+++ b/test/rules.txtar
@@ -28,6 +28,12 @@ stdout 'ADES103'
 stdout 'ADES104'
 ! stderr .
 
+# ADES105
+! exec ades ades105.yml
+! stdout 'Ok'
+stdout 'ADES105'
+! stderr .
+
 # ADES200
 ! exec ades ades200.yml
 ! stdout 'Ok'
@@ -101,6 +107,17 @@ jobs:
     - uses: sergeysova/jq-action@v2
       with:
         cmd: jq .version ${{ github.event.inputs.file }} -r
+-- ades105.yml --
+name: Example workflow with a ADES105 violation
+on: [push]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - shell: python
+      run: |
+        print('Hello ${{ inputs.name }}')
 -- ades200.yml --
 name: Example workflow with a ADES200 violation
 on: [push]


### PR DESCRIPTION
Relates to #384

## Summary

This adds a new rule to `ades` for `run:` steps that set the shell to Python. The motivation for this is that the fix is quite different, thus requiring a different explanation (and, in the future, fix). One potential user experience drawback of this approach is that it may be confusing that there's two rules for essentially the same mistake.