### PR TITLE
Replace Semgrep PRO with Semgrep OSS

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,6 @@
 name: Semgrep
 on:
+  pull_request: ~
   push:
     branches:
     - main
@@ -20,9 +21,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Perform Semgrep analysis
-      run: semgrep ci --sarif --output semgrep.sarif
-      env:
-        SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      run: semgrep --sarif --output semgrep.sarif
     - name: Upload Semgrep report to GitHub
       uses: github/codeql-action/upload-sarif@f6091c0113d1dcf9b98e269ee48e8a7e51b7bdd4 # v3.28.5
       if: ${{ failure() || success() }}


### PR DESCRIPTION
Relates to #379

## Summary

This updates the `semgrep.yml` workflow to run Semgrep OSS instead of Semgrep PRO. The tradeoff here is giving up some SAST rules and SSC support in favor of not needing an authentication token, running for all changes, allowing anyone to perform the scan locally, and no dependence on the availability of the Semgrep backend. Not to mention that we have SSC support covered through other means.