### PR TITLE
Ensure `-conservative` reports standalone expressions

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -53,11 +53,19 @@ var conservativeExprRegExp = regexp.MustCompile(`\${{.+?(github\.event\.issue\.t
 type conservativeExprMatcher struct{}
 
 func (m conservativeExprMatcher) FindAll(v []byte) [][]byte {
-	if conservativeExprRegExp.Find(stripSafe(v)) == nil {
+	if allExprRegExp.Find(stripSafe(v)) == nil {
 		return nil
 	}
 
-	return conservativeExprRegExp.FindAll(v, len(v))
+	all := allExprRegExp.FindAll(v, len(v))
+	conservative := make([][]byte, 0, len(all))
+	for _, candidate := range all {
+		if conservativeExprRegExp.Match(candidate) {
+			conservative = append(conservative, candidate)
+		}
+	}
+
+	return conservative
 }
 
 var (

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -353,8 +353,18 @@ func TestConservativeMatcher(t *testing.T) {
 			},
 		},
 
-		"unsafe and unsafe in one expression": {},
-		"two, only one is dangerous":          {},
+		"(conservatively) safe followed by (conservatively) unsafe": {
+			value: `gh pr create -B ${{ steps.head.outputs.name }} -H ${{ github.head_ref || github.ref_name }}`,
+			want: []string{
+				"${{ github.head_ref || github.ref_name }}",
+			},
+		},
+		"(conservatively) unsafe followed by (conservatively) safe": {
+			value: `gh pr create -H ${{ github.head_ref || github.ref_name }} -B ${{ steps.head.outputs.name }}`,
+			want: []string{
+				"${{ github.head_ref || github.ref_name }}",
+			},
+		},
 	}
 
 	for name, tt := range testCases {


### PR DESCRIPTION
Closes #500

## Summary

First, this adds test cases for the conservative matcher where two expressions appear in a row that might be matched as one big expression by a regular expression.

Second, this fixes the conservative matcher to avoid the above problem by 1) matching all workflow expressions and then 2) filtering those with the regex for the set of conservatively dangerous workflow expressions.