### PR TITLE
Move `stripSafe` responsibility

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -151,8 +151,13 @@ func analyzeStep(id int, step *gha.Step, matcher ExprMatcher) []Violation {
 }
 
 func analyzeString(s string, matcher ExprMatcher) []Violation {
+	b := []byte(s)
+	if len(matcher.FindAll(stripSafe(b))) == 0 {
+		return nil
+	}
+
 	violations := make([]Violation, 0)
-	if matches := matcher.FindAll([]byte(s)); matches != nil {
+	if matches := matcher.FindAll(b); matches != nil {
 		for _, problem := range matches {
 			violations = append(violations, Violation{
 				Problem: string(problem),

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -587,6 +587,18 @@ func TestAnalyzeString(t *testing.T) {
 				{Problem: "${{ input.name }}"},
 			},
 		},
+		"Safe expressions": {
+			value:   "echo '${{ true }} or ${{ false }}!'",
+			matcher: AllMatcher,
+			want:    nil,
+		},
+		"Partially safe expressions": {
+			value:   "echo '${{ true || input.sha }}'",
+			matcher: AllMatcher,
+			want: []Violation{
+				{Problem: "${{ true || input.sha }}"},
+			},
+		},
 	}
 
 	for name, tt := range testCases {

--- a/matchers.go
+++ b/matchers.go
@@ -41,10 +41,6 @@ var allExprRegExp = regexp.MustCompile(`\${{.*?}}`)
 type allExprMatcher struct{}
 
 func (m allExprMatcher) FindAll(v []byte) [][]byte {
-	if allExprRegExp.Find(stripSafe(v)) == nil {
-		return nil
-	}
-
 	return allExprRegExp.FindAll(v, len(v))
 }
 
@@ -80,10 +76,6 @@ var conservativeExps = []*regexp.Regexp{
 type conservativeExprMatcher struct{}
 
 func (m conservativeExprMatcher) FindAll(v []byte) [][]byte {
-	if allExprRegExp.Find(stripSafe(v)) == nil {
-		return nil
-	}
-
 	all := allExprRegExp.FindAll(v, len(v))
 	conservative := make([][]byte, 0, len(all))
 	for _, candidate := range all {

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -32,14 +32,6 @@ func TestAllMatcher(t *testing.T) {
 			value: `'Hello world'`,
 			want:  nil,
 		},
-		"safe expression": {
-			value: `${{ true }}`,
-			want:  nil,
-		},
-		"safe use of an unsafe expression": {
-			value: `${{ contains(github.event.issue.title, 'foobar') }}`,
-			want:  nil,
-		},
 		"unsafe expression ": {
 			value: `${{ foo.bar }}`,
 			want: []string{
@@ -118,10 +110,6 @@ func TestAllMatcher(t *testing.T) {
 				`${{ false || foo.baz }}`,
 			},
 		},
-		"safe & safe in one expression": {
-			value: `echo ${{ false || true }}`,
-			want:  nil,
-		},
 		"unsafe & unsafe in one expression": {
 			value: `${{ foo.bar || foo.baz }}`,
 			want: []string{
@@ -167,10 +155,6 @@ func TestConservativeMatcher(t *testing.T) {
 		},
 		"conservatively safe expression": {
 			value: `${{ input.greeting }}`,
-			want:  nil,
-		},
-		"safe use of conservatively unsafe expression": {
-			value: `${{ contains(github.event.issue.title, 'foobar') }}`,
 			want:  nil,
 		},
 		"github.event.issue.title": {


### PR DESCRIPTION
Relates to #411

## Summary

Refactor to remove the stripSafe responsibility from the `matcher`s to the caller/user of the `matcher`. This makes the matcher a bit more reusable (e.g. the caller can choose to user no or a different stripSafe function) and reduces a bit of duplication.