### PR TITLE
Add link to "Report a bug or suggestion" to the website

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -114,6 +114,14 @@ jobs:
 				rel="noopener"
 			>@ericcornelissen</a>.
 		</p>
+		<p>
+			<a
+				href="https://github.com/ericcornelissen/ades/issues/new?template=website.yml"
+				rel="noopener"
+			>
+				Report a bug or suggestion for this website.
+			</a>
+		</p>
 	</footer>
 
 	<script src="index.js"></script>


### PR DESCRIPTION
Relates to #520

## Summary

Add an explicit link to report bugs and suggestions to the website. Similar to the end of the `--help` message:

```text
Need more help? Found a bug? Missing something? See:
https://github.com/ericcornelissen/ades/issues/new/choose
```