### PR TITLE
Set "Referrer-Policy" for the website

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		http-equiv="Content-Security-Policy"
 		content="base-uri 'none'; connect-src 'self'; default-src 'none'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; trusted-types 'none'; require-trusted-types-for 'script';"
 	/>
+	<meta
+		http-equiv="Referrer-Policy"
+		content="no-referrer"
+	/>
 
 	<link rel="stylesheet" href="index.css">
 	<script src="wasm_exec.js"></script>


### PR DESCRIPTION
Relates to #355, #528

## Summary

Set a ["Referrer-Policy"](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Referrer_policy) for the website using a meta tag (similar to the CSP policy). This aims to increase privacy for users.

I found out about this by running the [Mozilla HTTP Observatory](https://developer.mozilla.org/en-US/observatory) on another project of mine.