### PR TITLE
Implement matrix-based safe expressions filter

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -97,6 +97,10 @@ func analyzeJob(id string, job *gha.Job, matcher ExprMatcher) []Violation {
 
 	violations := make([]Violation, 0)
 	for _, violation := range analyzeSteps(job.Steps, matcher) {
+		if matrixSafe(violation.Problem, job.Strategy.Matrix, matcher) {
+			continue
+		}
+
 		violation.jobKey = id
 		violation.JobId = name
 		violations = append(violations, violation)

--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/nilaway v0.0.0-20241010202415-ba14292918d8 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240213143201-ec583247a57a // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect
@@ -176,7 +175,6 @@ tool (
 	github.com/tetafro/godot/cmd/godot
 	github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck
 	github.com/ultraware/whitespace/cmd/whitespace
-	go.uber.org/nilaway/cmd/nilaway
 	golang.org/x/tools/cmd/deadcode
 	golang.org/x/tools/cmd/goimports
 	golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ericcornelissen/ades
 go 1.24.4
 
 require (
-	github.com/ericcornelissen/go-gha-models v0.4.3
+	github.com/ericcornelissen/go-gha-models v0.5.1
 	github.com/gtramontina/ooze v0.2.0
 	github.com/playwright-community/playwright-go v0.5200.0
 	github.com/rogpeppe/go-internal v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ericcornelissen/go-gha-models v0.4.3 h1:S12HL4kJra0qeLQWYu8xXNBDbrkMK9ZWFfp61zXFXLY=
-github.com/ericcornelissen/go-gha-models v0.4.3/go.mod h1:gKKrR6vGsh05itUho8QrRQLuN+8xfrMbzbO7wR+NelE=
+github.com/ericcornelissen/go-gha-models v0.5.1 h1:sIP7h7/K47qzkmYNcyNzpMoHiCTzkgOM/UrzpMlNnuk=
+github.com/ericcornelissen/go-gha-models v0.5.1/go.mod h1:gKKrR6vGsh05itUho8QrRQLuN+8xfrMbzbO7wR+NelE=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,6 @@ github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1Fof
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -332,10 +330,6 @@ go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/nilaway v0.0.0-20241010202415-ba14292918d8 h1:3mxcSin88plhfjoT2FW0IaDmdcZTvpMVrhXVnF4Abcc=
-go.uber.org/nilaway v0.0.0-20241010202415-ba14292918d8/go.mod h1:zblyZlFADuRGKrmjHFrqfnBEUeE8QJZNeZRV8hnZnUw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/matrix.go
+++ b/matrix.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2025  Eric Cornelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package ades
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/ericcornelissen/go-gha-models"
+)
+
+var matrixExprRegExp = regexp.MustCompile(`matrix\.[a-z._-]+`)
+
+// Check if the expression is safe under the given matrix.
+func matrixSafe(expr string, matrix gha.Matrix, matcher ExprMatcher) bool {
+	matrixExprs := matrixExprRegExp.FindAllString(expr, len(expr))
+	for _, expr := range matrixExprs {
+		values := getMatrixValues(expr, matrix.Matrix)
+		for _, include := range matrix.Include {
+			values = append(values, getMatrixValues(expr, include)...)
+		}
+
+		if len(values) == 0 {
+			return false
+		}
+
+		for _, value := range values {
+			if violations := analyzeString(value, matcher); len(violations) > 0 {
+				return false
+			}
+		}
+	}
+
+	for _, match := range matrixExprs {
+		expr = strings.ReplaceAll(expr, match, "")
+	}
+	if violations := analyzeString(expr, matcher); len(violations) != 0 {
+		return false
+	}
+
+	return true
+}
+
+// Get all possible values of the given matrix expression from the given matrix.
+func getMatrixValues(expr string, matrix map[string]any) []string {
+	expr, _ = strings.CutPrefix(expr, "matrix.")
+
+	parts := strings.Split(expr, ".")
+	head, tail := parts[0], parts[1:]
+
+	if value, ok := matrix[head]; ok {
+		switch tmp := value.(type) {
+		case map[string]any:
+			expr := strings.Join(tail, ".")
+			return getMatrixValues(expr, tmp)
+		case []any:
+			var values []string
+			for _, tmp := range tmp {
+				switch tmp := tmp.(type) {
+				case string:
+					values = append(values, tmp)
+				case map[string]any:
+					expr := strings.Join(tail, ".")
+					values = append(values, getMatrixValues(expr, tmp)...)
+				}
+			}
+			return values
+		case any:
+			value, _ := tmp.(string)
+			return []string{value}
+		}
+	}
+
+	return nil
+}

--- a/tasks.go
+++ b/tasks.go
@@ -544,7 +544,6 @@ func TaskVet(t *T) error {
 		"go run github.com/tetafro/godot/cmd/godot .",
 		"go run github.com/tomarrell/wrapcheck/v2/cmd/wrapcheck ./...",
 		"go run github.com/ultraware/whitespace/cmd/whitespace ./...",
-		"go run go.uber.org/nilaway/cmd/nilaway ./...",
 		"go run golang.org/x/tools/cmd/deadcode ./...",
 		"go run golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow ./...",
 		"go run honnef.co/go/tools/cmd/staticcheck ./...",


### PR DESCRIPTION
Relates to #366

## Summary

Add logic to filter out expressions with matrix values that always instantiate to a trusted value. This is achieved by checking all possible values of matrix expression against the same `ExprMatcher` - if the instantiated values are fine then the matrix expression is fine too.