### PR TITLE
Cover `roots/issue-closer-action` in addition to `roots/issue-closer`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -64,17 +64,17 @@ it can be made safer by converting it into:
 #                       | Note: the use of backticks is required in this example (for interpolation)
 ```
 
-## <a id="ADES102"></a> ADES102 - Expression in `roots/issue-closer` issue close message
+## <a id="ADES102"></a> ADES102 - Expression in `roots/issue-closer-action` issue close message
 
-When an expression appears in the issue close message of `roots/issue-closer` it is interpreted as
-an ES6-style template literal. You can avoid potential attacks by extracting the expression into an
-environment variable and using the environment variable instead.
+When an expression appears in the issue close message of `roots/issue-closer-action` it is
+interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
+expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
 ```yaml
 - name: Example step
-  uses: roots/issue-closer@v1
+  uses: roots/issue-closer-action@v1
   with:
     issue-close-message: Closing ${{ github.event.issue.title }}
 ```
@@ -83,7 +83,7 @@ it can be made safer by converting it into:
 
 ```yaml
 - name: Example step
-  uses: roots/issue-closer@v1
+  uses: roots/issue-closer-action@v1
   env:
     NAME: ${{ github.event.issue.title }} # <- Assign the expression to an environment variable
   with:
@@ -92,9 +92,9 @@ it can be made safer by converting it into:
   #                              | Replace the expression with the environment variable
 ```
 
-## <a id="ADES103"></a> ADES103 - Expression in `roots/issue-closer` pull request close message
+## <a id="ADES103"></a> ADES103 - Expression in `roots/issue-closer-action` pull request close message
 
-When an expression appears in the pull request close message of `roots/issue-closer` it is
+When an expression appears in the pull request close message of `roots/issue-closer-action` it is
 interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
@@ -102,7 +102,7 @@ For example, given the workflow snippet:
 
 ```yaml
 - name: Example step
-  uses: roots/issue-closer@v1
+  uses: roots/issue-closer-action@v1
   with:
     pr-close-message: Closing ${{ github.event.issue.title }}
 ```
@@ -111,7 +111,7 @@ it can be made safer by converting it into:
 
 ```yaml
 - name: Example step
-  uses: roots/issue-closer@v1
+  uses: roots/issue-closer-action@v1
   env:
     NAME: ${{ github.event.issue.title }} # <- Assign the expression to an environment variable
   with:

--- a/rules.go
+++ b/rules.go
@@ -158,29 +158,29 @@ this, upgrade the action to a non-vulnerable version.`,
 	},
 }
 
-var actionRuleRootsIssueCloserIssueCloseMessage = actionRule{
+var actionRuleRootsIssueCloserActionIssueCloseMessage = actionRule{
 	appliesTo: func(_ *gha.Uses) bool {
 		return true
 	},
 	rule: rule{
 		id:    "ADES102",
-		title: "Expression in 'roots/issue-closer' issue close message",
+		title: "Expression in 'roots/issue-closer-action' issue close message",
 		description: `
-When an expression appears in the issue close message of 'roots/issue-closer' it is interpreted as
-an ES6-style template literal. You can avoid potential attacks by extracting the expression into an
-environment variable and using the environment variable instead.
+When an expression appears in the issue close message of 'roots/issue-closer-action' it is
+interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
+expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
     - name: Example step
-      uses: roots/issue-closer@v1
+      uses: roots/issue-closer-action@v1
       with:
         issue-close-message: Closing ${{ github.event.issue.title }}
 
 it can be made safer by converting it into:
 
     - name: Example step
-      uses: roots/issue-closer@v1
+      uses: roots/issue-closer-action@v1
       env:
         NAME: ${{ github.event.issue.title }} # <- Assign the expression to an environment variable
       with:
@@ -216,29 +216,29 @@ it can be made safer by converting it into:
 	},
 }
 
-var actionRuleRootsIssueCloserPrCloseMessage = actionRule{
+var actionRuleRootsIssueCloserActionPrCloseMessage = actionRule{
 	appliesTo: func(_ *gha.Uses) bool {
 		return true
 	},
 	rule: rule{
 		id:    "ADES103",
-		title: "Expression in 'roots/issue-closer' pull request close message",
+		title: "Expression in 'roots/issue-closer-action' pull request close message",
 		description: `
-When an expression appears in the pull request close message of 'roots/issue-closer' it is
+When an expression appears in the pull request close message of 'roots/issue-closer-action' it is
 interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
 For example, given the workflow snippet:
 
     - name: Example step
-      uses: roots/issue-closer@v1
+      uses: roots/issue-closer-action@v1
       with:
         pr-close-message: Closing ${{ github.event.issue.title }}
 
 it can be made safer by converting it into:
 
     - name: Example step
-      uses: roots/issue-closer@v1
+      uses: roots/issue-closer-action@v1
       env:
         NAME: ${{ github.event.issue.title }} # <- Assign the expression to an environment variable
       with:
@@ -304,9 +304,13 @@ var actionRules = map[string][]actionRule{
 	"kceb/git-message-action": {
 		actionRuleKcebGitMessageAction,
 	},
+	"roots/issue-closer-action": {
+		actionRuleRootsIssueCloserActionIssueCloseMessage,
+		actionRuleRootsIssueCloserActionPrCloseMessage,
+	},
 	"roots/issue-closer": {
-		actionRuleRootsIssueCloserIssueCloseMessage,
-		actionRuleRootsIssueCloserPrCloseMessage,
+		actionRuleRootsIssueCloserActionIssueCloseMessage,
+		actionRuleRootsIssueCloserActionPrCloseMessage,
 	},
 	"sergeysova/jq-action": {
 		actionRuleSergeysovaJqAction,

--- a/rules_test.go
+++ b/rules_test.go
@@ -283,13 +283,13 @@ func TestActionRuleKcebGitMessageAction(t *testing.T) {
 	})
 }
 
-func TestActionRulesRootsIssueCloser(t *testing.T) {
+func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 	t.Run("issue-close-message", func(t *testing.T) {
 		t.Run("Applies to", func(t *testing.T) {
 			f := func(uses gha.Uses, ref string) bool {
 				uses.Name = "roots/issue-closer"
 				uses.Ref = ref
-				return actionRuleRootsIssueCloserIssueCloseMessage.appliesTo(&uses)
+				return actionRuleRootsIssueCloserActionIssueCloseMessage.appliesTo(&uses)
 			}
 
 			if err := quick.Check(f, nil); err != nil {
@@ -300,7 +300,7 @@ func TestActionRulesRootsIssueCloser(t *testing.T) {
 		t.Run("Extract from", func(t *testing.T) {
 			withIssueCloseMessage := func(step gha.Step, message string) bool {
 				step.With["issue-close-message"] = message
-				return actionRuleRootsIssueCloserIssueCloseMessage.rule.extractFrom(&step) == message
+				return actionRuleRootsIssueCloserActionIssueCloseMessage.rule.extractFrom(&step) == message
 			}
 			if err := quick.Check(withIssueCloseMessage, nil); err != nil {
 				t.Error(err)
@@ -308,7 +308,7 @@ func TestActionRulesRootsIssueCloser(t *testing.T) {
 
 			withoutIssueCloseMessage := func(step gha.Step) bool {
 				delete(step.With, "issue-close-message")
-				return actionRuleRootsIssueCloserIssueCloseMessage.rule.extractFrom(&step) == ""
+				return actionRuleRootsIssueCloserActionIssueCloseMessage.rule.extractFrom(&step) == ""
 			}
 			if err := quick.Check(withoutIssueCloseMessage, nil); err != nil {
 				t.Error(err)
@@ -321,7 +321,7 @@ func TestActionRulesRootsIssueCloser(t *testing.T) {
 			f := func(uses gha.Uses, ref string) bool {
 				uses.Name = "roots/issue-closer"
 				uses.Ref = ref
-				return actionRuleRootsIssueCloserPrCloseMessage.appliesTo(&uses)
+				return actionRuleRootsIssueCloserActionPrCloseMessage.appliesTo(&uses)
 			}
 
 			if err := quick.Check(f, nil); err != nil {
@@ -332,7 +332,7 @@ func TestActionRulesRootsIssueCloser(t *testing.T) {
 		t.Run("Extract from", func(t *testing.T) {
 			withIssueCloseMessage := func(step gha.Step, message string) bool {
 				step.With["pr-close-message"] = message
-				return actionRuleRootsIssueCloserPrCloseMessage.rule.extractFrom(&step) == message
+				return actionRuleRootsIssueCloserActionPrCloseMessage.rule.extractFrom(&step) == message
 			}
 			if err := quick.Check(withIssueCloseMessage, nil); err != nil {
 				t.Error(err)
@@ -340,7 +340,7 @@ func TestActionRulesRootsIssueCloser(t *testing.T) {
 
 			withoutIssueCloseMessage := func(step gha.Step) bool {
 				delete(step.With, "pr-close-message")
-				return actionRuleRootsIssueCloserPrCloseMessage.rule.extractFrom(&step) == ""
+				return actionRuleRootsIssueCloserActionPrCloseMessage.rule.extractFrom(&step) == ""
 			}
 			if err := quick.Check(withoutIssueCloseMessage, nil); err != nil {
 				t.Error(err)
@@ -425,10 +425,7 @@ func TestAllRules(t *testing.T) {
 	t.Run("id", func(t *testing.T) {
 		idExpr := regexp.MustCompile(`ADES\d{3}`)
 
-		ids := make([]string, 0)
 		for _, tt := range testCases {
-			ids = append(ids, tt.id)
-
 			t.Run(tt.title, func(t *testing.T) {
 				t.Parallel()
 
@@ -439,13 +436,13 @@ func TestAllRules(t *testing.T) {
 		}
 
 		t.Run("unique", func(t *testing.T) {
-			uniqueIds := make(map[string]any, len(ids))
-			for _, id := range ids {
-				if _, ok := uniqueIds[id]; ok {
-					t.Errorf("Found repeated ID %q", id)
+			ids := make(map[string]rule, len(testCases))
+			for _, tt := range testCases {
+				if got, ok := ids[tt.id]; ok && tt.title != got.title {
+					t.Errorf("Found repeated ID %q", tt.id)
 				}
 
-				uniqueIds[id] = true
+				ids[tt.id] = tt
 			}
 		})
 	})

--- a/test/rules.txtar
+++ b/test/rules.txtar
@@ -11,13 +11,23 @@ stdout 'ADES101'
 ! stderr .
 
 # ADES102
-! exec ades ades102.yml
+! exec ades ades102-1.yml
+! stdout 'Ok'
+stdout 'ADES102'
+! stderr .
+
+! exec ades ades102-2.yml
 ! stdout 'Ok'
 stdout 'ADES102'
 ! stderr .
 
 # ADES103
-! exec ades ades103.yml
+! exec ades ades103-1.yml
+! stdout 'Ok'
+stdout 'ADES103'
+! stderr .
+
+! exec ades ades103-2.yml
 ! stdout 'Ok'
 stdout 'ADES103'
 ! stderr .
@@ -74,7 +84,18 @@ jobs:
     - uses: actions/github-script@v6
       with:
         script: console.log('Hello ${{ inputs.name }}')
--- ades102.yml --
+-- ades102-1.yml --
+name: Example workflow with a ADES102 violation
+on: [push]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: roots/issue-closer-action@v1
+      with:
+        issue-close-message: Closing ${{ github.event.issue.title }}
+-- ades102-2.yml --
 name: Example workflow with a ADES102 violation
 on: [push]
 
@@ -85,7 +106,18 @@ jobs:
     - uses: roots/issue-closer@v1
       with:
         issue-close-message: Closing ${{ github.event.issue.title }}
--- ades103.yml --
+-- ades103-1.yml --
+name: Example workflow with a ADES103 violation
+on: [push]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: roots/issue-closer-action@v1
+      with:
+        pr-close-message: Closing ${{ github.event.issue.title }}
+-- ades103-2.yml --
 name: Example workflow with a ADES103 violation
 on: [push]
 


### PR DESCRIPTION
Closes #554

Despite what the issue says, detection for the old name has been kept as it's still possible to use as such (verified today) and the docs for the action still point to the old name.