### PR TITLE
Add test for Grafana Labs' 2025-04-27 CI incident

### DIFF
--- a/test/advisories.txtar
+++ b/test/advisories.txtar
@@ -64,6 +64,12 @@ stdout 'Ok'
 exec ades -conservative 'GHSA-65rg-554r-9j5x/'
 stdout 'Ok'
 
+# Grafana Labs 2025-04-27
+! exec ades 'grafana-labs-2025-04-27/'
+! stdout 'Ok'
+! exec ades -conservative 'grafana-labs-2025-04-27/'
+! stdout 'Ok'
+
 
 -- GHSA-7x29-qqmq-v6qc/action.yml --
 # Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
@@ -1080,3 +1086,52 @@ runs:
 branding:
   icon: "external-link"
   color: "purple"
+-- grafana-labs-2025-04-27/.github/workflows/pr-patch-check-event.yml --
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo Ex: grafana/grafana
+name: Dispatch check for patch conflicts
+run-name: dispatch-check-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - "main"
+      - "v*.*.*"
+      - "release-*"
+
+# Since this is run on a pull request, we want to apply the patches intended for the
+# target branch onto the source branch, to verify compatibility before merging.
+jobs:
+  dispatch-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          # App needs Actions: Read/Write for the grafana/security-patch-actions repo
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - name: "Dispatch job"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+                owner: 'grafana',
+                repo: 'security-patch-actions',
+                workflow_id: 'test-patches-event.yml',
+                ref: 'main',
+                inputs: {
+                  src_repo: "${{ github.repository }}",
+                  src_ref: "${{ github.head_ref }}",
+                  src_merge_sha: "${{ github.sha }}",
+                  src_pr_commit_sha: "${{ github.event.pull_request.head.sha }}",
+                  patch_repo: "${{ github.repository }}-security-patches",
+                  patch_ref: "${{ github.base_ref }}",
+                  triggering_github_handle: "${{ github.event.sender.login }}"
+                }
+            })


### PR DESCRIPTION
Relates to #288

## Summary

This creates a test for the [Grafana Labs' 2025-04-27 CI incident](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/) as described in [this comment](https://github.com/ericcornelissen/ades/issues/288#issuecomment-2841791522).