### PR TITLE
Add a rule for the input of `cardinalby/js-eval-action`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -159,6 +159,34 @@ without risking injection.
 Do NOT pass environment variables into the container through the action's options input. This opens
 up alternative attack vectors because the options are not validated.
 
+## <a id="ADES106"></a> ADES106 - Expression in `cardinalby/js-eval-action` expression input
+
+When an expression appears in the expression input of `cardinalby/js-eval-action` you can avoid any
+potential attack by extracting the expression into an environment variable and using the environment
+variable instead.
+
+For example, given the workflow snippet:
+
+```yaml
+- name: Example step
+  uses: cardinalby/js-eval-action@v1
+  with:
+    expression: 1 + parseInt(${{ inputs.value }})
+```
+
+it can be made safer by converting it into:
+
+```yaml
+- name: Example step
+  uses: cardinalby/js-eval-action@v1
+  env:
+    VALUE: ${{ inputs.value }} # <- Assign the expression to an environment variable
+  with:
+    expression: 1 + parseInt(env.VALUE)
+  #                          ^^^^^^^^^
+  #                          | Replace the expression with the environment variable
+```
+
 ## <a id="ADES200"></a> ADES200 - Expression in `ericcornelissen/git-tag-annotation-action` tag input
 
 When an expression is used in the tag input for `ericcornelissen/git-tag-annotation-action` in

--- a/analyze_test.go
+++ b/analyze_test.go
@@ -419,8 +419,8 @@ func TestAnalyzeJob(t *testing.T) {
 					Matrix: gha.Matrix{
 						Matrix: map[string]any{
 							"field": []any{
-								"${{ input.unsafe }}",
-								"${{ input.also-unsafe }}",
+								"${{ inputs.unsafe }}",
+								"${{ inputs.also-unsafe }}",
 							},
 						},
 					},
@@ -463,7 +463,7 @@ func TestAnalyzeJob(t *testing.T) {
 					Matrix: gha.Matrix{
 						Include: []map[string]any{
 							{
-								"field": "${{ input.unsafe }}",
+								"field": "${{ inputs.unsafe }}",
 							},
 						},
 					},
@@ -506,7 +506,7 @@ func TestAnalyzeJob(t *testing.T) {
 					Matrix: gha.Matrix{
 						Matrix: map[string]any{
 							"foo": map[string]any{
-								"bar": "${{ input.unsafe }}",
+								"bar": "${{ inputs.unsafe }}",
 							},
 						},
 					},
@@ -533,7 +533,7 @@ func TestAnalyzeJob(t *testing.T) {
 				},
 				Steps: []gha.Step{
 					{
-						Run: "echo ${{ matrix.field || input.unsafe }}",
+						Run: "echo ${{ matrix.field || inputs.unsafe }}",
 					},
 				},
 			},
@@ -561,7 +561,7 @@ func TestAnalyzeJob(t *testing.T) {
 					Matrix: gha.Matrix{
 						Matrix: map[string]any{
 							"foo": map[string]any{
-								"bar": "${{ input.unsafe }}",
+								"bar": "${{ inputs.unsafe }}",
 							},
 						},
 					},
@@ -583,7 +583,7 @@ func TestAnalyzeJob(t *testing.T) {
 					Matrix: gha.Matrix{
 						Matrix: map[string]any{
 							"foo": "safe",
-							"bar": "${{ input.unsafe }}",
+							"bar": "${{ inputs.unsafe }}",
 						},
 					},
 				},
@@ -653,7 +653,7 @@ func TestAnalyzeJob(t *testing.T) {
 									"bar": "safe",
 								},
 								map[string]any{
-									"bar": "${{ input.unsafe }}",
+									"bar": "${{ inputs.unsafe }}",
 								},
 							},
 						},
@@ -871,18 +871,18 @@ func TestAnalyzeString(t *testing.T) {
 			want:    []Violation{},
 		},
 		"One violations": {
-			value:   "echo 'Hello ${{ input.name }}!'",
+			value:   "echo 'Hello ${{ inputs.name }}!'",
 			matcher: AllMatcher,
 			want: []Violation{
-				{Problem: "${{ input.name }}"},
+				{Problem: "${{ inputs.name }}"},
 			},
 		},
 		"Two violations": {
-			value:   "echo '${{ input.greeting }} ${{ input.name }}!'",
+			value:   "echo '${{ inputs.greeting }} ${{ inputs.name }}!'",
 			matcher: AllMatcher,
 			want: []Violation{
-				{Problem: "${{ input.greeting }}"},
-				{Problem: "${{ input.name }}"},
+				{Problem: "${{ inputs.greeting }}"},
+				{Problem: "${{ inputs.name }}"},
 			},
 		},
 		"Safe expressions": {
@@ -891,10 +891,10 @@ func TestAnalyzeString(t *testing.T) {
 			want:    nil,
 		},
 		"Partially safe expressions": {
-			value:   "echo '${{ true || input.sha }}'",
+			value:   "echo '${{ true || inputs.sha }}'",
 			matcher: AllMatcher,
 			want: []Violation{
-				{Problem: "${{ true || input.sha }}"},
+				{Problem: "${{ true || inputs.sha }}"},
 			},
 		},
 	}

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -39,9 +39,9 @@ func TestAllMatcher(t *testing.T) {
 			},
 		},
 		"input expression": {
-			value: `${{ input.greeting }}`,
+			value: `${{ inputs.greeting }}`,
 			want: []string{
-				`${{ input.greeting }}`,
+				`${{ inputs.greeting }}`,
 			},
 		},
 		"matrix expression": {
@@ -154,7 +154,7 @@ func TestConservativeMatcher(t *testing.T) {
 			want:  nil,
 		},
 		"conservatively safe expression": {
-			value: `${{ input.greeting }}`,
+			value: `${{ inputs.greeting }}`,
 			want:  nil,
 		},
 		"github.event.issue.title": {
@@ -595,7 +595,7 @@ func TestDefinitelySafe(t *testing.T) {
 			want:  `echo 'hash: '`,
 		},
 		"function, hashFiles, with variables": {
-			value: `echo 'hash: ${{ hashFiles(input.files) }}'`,
+			value: `echo 'hash: ${{ hashFiles(inputs.files) }}'`,
 			want:  `echo 'hash: '`,
 		},
 		"function, join, no variables": {

--- a/rules.go
+++ b/rules.go
@@ -124,6 +124,42 @@ upgrade the action to a non-vulnerable version.`,
 	},
 }
 
+var actionRuleCardinalbyJsEvalAction = actionRule{
+	appliesTo: func(_ *gha.Uses) bool {
+		return true
+	},
+	rule: rule{
+		id:    "ADES106",
+		title: "Expression in 'cardinalby/js-eval-action' expression input",
+		description: `
+When an expression appears in the expression input of 'cardinalby/js-eval-action' you can avoid any
+potential attack by extracting the expression into an environment variable and using the environment
+variable instead.
+
+For example, given the workflow snippet:
+
+    - name: Example step
+      uses: cardinalby/js-eval-action@v1
+      with:
+        expression: 1 + parseInt(${{ inputs.value }})
+
+it can be made safer by converting it into:
+
+    - name: Example step
+      uses: cardinalby/js-eval-action@v1
+      env:
+        VALUE: ${{ inputs.value }} # <- Assign the expression to an environment variable
+      with:
+        expression: 1 + parseInt(env.VALUE)
+      #                          ^^^^^^^^^
+      #                          | Replace the expression with the environment variable
+`,
+		extractFrom: func(step *gha.Step) string {
+			return step.With["expression"]
+		},
+	},
+}
+
 var actionRuleEriccornelissenGitTagAnnotationAction = actionRule{
 	appliesTo: func(uses *gha.Uses) bool {
 		return isBeforeVersion(uses, "v1.0.1")
@@ -297,6 +333,9 @@ var actionRules = map[string][]actionRule{
 	},
 	"atlassian/gajira-create": {
 		actionRuleAtlassianGajiraCreate,
+	},
+	"cardinalby/js-eval-action": {
+		actionRuleCardinalbyJsEvalAction,
 	},
 	"ericcornelissen/git-tag-annotation-action": {
 		actionRuleEriccornelissenGitTagAnnotationAction,

--- a/rules_test.go
+++ b/rules_test.go
@@ -57,6 +57,38 @@ func TestActionRuleActionsGithubScript(t *testing.T) {
 	})
 }
 
+func TestActionRuleAddnabDockerRunAction(t *testing.T) {
+	t.Run("Applies to", func(t *testing.T) {
+		f := func(uses gha.Uses, ref string) bool {
+			uses.Name = "addnab/docker-run-action"
+			uses.Ref = ref
+			return actionRuleAddnabDockerRunAction.appliesTo(&uses)
+		}
+
+		if err := quick.Check(f, nil); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("Extract from", func(t *testing.T) {
+		withRun := func(step gha.Step, run string) bool {
+			step.With["run"] = run
+			return actionRuleAddnabDockerRunAction.rule.extractFrom(&step) == run
+		}
+		if err := quick.Check(withRun, nil); err != nil {
+			t.Error(err)
+		}
+
+		withoutRun := func(step gha.Step) bool {
+			delete(step.With, "run")
+			return actionRuleAddnabDockerRunAction.rule.extractFrom(&step) == ""
+		}
+		if err := quick.Check(withoutRun, nil); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
 func TestActionRuleAtlassianGajiraCreate(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
 		type TestCase struct {
@@ -121,35 +153,33 @@ func TestActionRuleAtlassianGajiraCreate(t *testing.T) {
 	})
 }
 
-func TestActionRuleAddnabDockerRunAction(t *testing.T) {
+func TestActionRuleCardinalbyJsEvalAction(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		t.Run("Applies to", func(t *testing.T) {
-			f := func(uses gha.Uses, ref string) bool {
-				uses.Name = "addnab/docker-run-action"
-				uses.Ref = ref
-				return actionRuleAddnabDockerRunAction.appliesTo(&uses)
-			}
+		f := func(uses gha.Uses, ref string) bool {
+			uses.Name = "cardinalby/js-eval-action"
+			uses.Ref = ref
+			return actionRuleCardinalbyJsEvalAction.appliesTo(&uses)
+		}
 
-			if err := quick.Check(f, nil); err != nil {
-				t.Error(err)
-			}
-		})
+		if err := quick.Check(f, nil); err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("Extract from", func(t *testing.T) {
-		withRun := func(step gha.Step, run string) bool {
-			step.With["run"] = run
-			return actionRuleAddnabDockerRunAction.rule.extractFrom(&step) == run
+		with := func(step gha.Step, expression string) bool {
+			step.With["expression"] = expression
+			return actionRuleCardinalbyJsEvalAction.rule.extractFrom(&step) == expression
 		}
-		if err := quick.Check(withRun, nil); err != nil {
+		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
 		}
 
-		withoutRun := func(step gha.Step) bool {
-			delete(step.With, "run")
-			return actionRuleAddnabDockerRunAction.rule.extractFrom(&step) == ""
+		without := func(step gha.Step) bool {
+			delete(step.With, "expression")
+			return actionRuleCardinalbyJsEvalAction.rule.extractFrom(&step) == ""
 		}
-		if err := quick.Check(withoutRun, nil); err != nil {
+		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
 		}
 	})

--- a/test/rules.txtar
+++ b/test/rules.txtar
@@ -44,6 +44,12 @@ stdout 'ADES104'
 stdout 'ADES105'
 ! stderr .
 
+# ADES106
+! exec ades ades106.yml
+! stdout 'Ok'
+stdout 'ADES106'
+! stderr .
+
 # ADES200
 ! exec ades ades200.yml
 ! stdout 'Ok'
@@ -152,6 +158,17 @@ jobs:
         image: ubuntu:latest
         run: |
           echo 'Hello ${{ env.name }}'
+-- ades106.yml --
+name: Example workflow with a ADES106 violation
+on: [push]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cardinalby/js-eval-action@v1
+      with:
+        expression: 'Hello ${{ env.name }}'
 -- ades200.yml --
 name: Example workflow with a ADES200 violation
 on: [push]
@@ -162,7 +179,7 @@ jobs:
     steps:
     - uses: ericcornelissen/git-tag-annotation-action@v1.0.0
       with:
-        tag: ${{ input.tag }}
+        tag: ${{ inputs.tag }}
 -- ades201.yml --
 name: Example workflow with a ADES201 violation
 on: [push]
@@ -173,7 +190,7 @@ jobs:
     steps:
     - uses: kceb/git-message-action@v1.1.0
       with:
-        sha: ${{ input.sha }}
+        sha: ${{ inputs.sha }}
 -- ades202.yml --
 name: Example workflow with a ADES202 violation
 on: [push]


### PR DESCRIPTION
Relates to #553

## Summary

Create and test the rule in line with the Contributing Guidelines as well as other rule implementations.

Also correct example expressions that used `input` to (correctly) use `inputs` instead.