### PR TITLE
Create rule for the SonarSource/sonarqube-scan-action vulnerability

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -208,3 +208,11 @@ it may be used to execute arbitrary JavaScript code, see [GHSA-4xqx-pqpj-9fqw]. 
 upgrade the action to a non-vulnerable version.
 
 [GHSA-4xqx-pqpj-9fqw]: https://github.com/advisories/GHSA-4xqx-pqpj-9fqw
+
+## <a id="ADES203"></a> ADES203 - Expression in `SonarSource/sonarqube-scan-action` args input
+
+When an expression is used in the args input for `SonarSource/sonarqube-scan-action` between v4.0.0
+and v5.3.0 it may be used to execute arbitrary Bash code, see [GHSA-f79p-9c5r-xg88]. To mitigate
+this, upgrade the action to a non-vulnerable version.
+
+[GHSA-f79p-9c5r-xg88]: https://github.com/advisories/GHSA-f79p-9c5r-xg88

--- a/test/rules.txtar
+++ b/test/rules.txtar
@@ -68,6 +68,12 @@ stdout 'ADES201'
 stdout 'ADES202'
 ! stderr .
 
+# ADES203
+! exec ades ades203.yml
+! stdout 'Ok'
+stdout 'ADES203'
+! stderr .
+
 
 -- ades100.yml --
 name: Example workflow with a ADES100 violation
@@ -205,3 +211,14 @@ jobs:
           ${{ github.event.issue.title }}
           description: |
           ${{ github.event.issue.body }}
+-- ades203.yml --
+name: Example workflow with a ADES203 violation
+on: [push]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: SonarSource/sonarqube-scan-action@v5.0.0
+      with:
+        args: ${{ inputs.args }}


### PR DESCRIPTION
Relates to #288, #399

## Summary

Define `ADES203` to detect workflows vulnerable to GHSA-f79p-9c5r-xg88.