### PR TITLE
Automatically modernize the code base once a month

### DIFF
--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -5,6 +5,7 @@ actions/attest-build-provenance@864457a58d4733d7f1574bd8821fa24e02cf7538 XNMz7LH
 actions/attest-build-provenance@v3.0.0 OVQyvZqzPBwqFMxYdJt2p/XpuM5BcwN/QDeTgYVd0Hc=
 actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 AlPt1CKAf/W8V8QEUcfVJopo9v7wGzR2WN0NRaf6HRk=
 actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 aYx2ZNrV/U9daVa5XJLnuR3depD7lQqzkyRhH4E9bOU=
+actions/create-github-app-token@v2.1.4 uqlqnKf5T6xNHHXE9Sm/5O+jRn++MUYS+//y1sojJ9I=
 actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 0qLZUqMcil7hZ8idJYYxI/LgdETqnWR0T02izCncHy4=
 docker/build-push-action@v6.17.0 JSBiASwiRckIi1Wp4xJz7zlr/fU3g9lZK9k212ed574=
 docker/login-action@v3.6.0 4RAwqK9AsSvSEtV9RMGVQo+3jz9tsgNg9UyqMVfA/vE=
@@ -12,4 +13,5 @@ docker/setup-buildx-action@v3.11.1 ZSQQmzmjsPIJZdqrOUcuNs24j01PJ/r4ff0LDxkvXMk=
 github/codeql-action@f443b600d91635bebf5b0d9ebc620189c0d6fba5 lG0J3cOgZTtK3vHMAICeAtolBdICTaE8CRiCBwI5+wY=
 github/codeql-action@v4.30.8 lG0J3cOgZTtK3vHMAICeAtolBdICTaE8CRiCBwI5+wY=
 ncipollo/release-action@v1.20.0 x49H6hPD8AWXRzcWpr1XIT5RoPcHJ/4QprD1vkG7ZnA=
+peter-evans/create-pull-request@v7.0.8 mLlQVah+/7e9weuwk4TdF2eVvnLQebPygPm+TfUdpKk=
 sigstore/cosign-installer@v4.0.0 9G7ZrM2Fr/B0uwOObCSa6gMY4kv7spg439EVhNZZjds=

--- a/.github/workflows/modernize.yml
+++ b/.github/workflows/modernize.yml
@@ -1,0 +1,47 @@
+name: Modernize
+on:
+  schedule:
+  - cron: "0 0 1 * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  modernize:
+    name: Modernize
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # To push a commit
+      pull-requests: write # To open a Pull Request
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+    - name: Install Go
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version-file: go.mod
+    - name: Verify action checksums
+      uses: ./.github/actions/ghasum
+    - name: Create automation token
+      uses: actions/create-github-app-token@v2.1.4
+      id: automation-token
+      with:
+        app-id: ${{ secrets.AUTOMATION_APP_ID }}
+        private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+    - name: Modernize
+      run: |
+        go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest \
+          -fix -test \
+          ./...
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7.0.8
+      with:
+        token: ${{ steps.automation-token.outputs.token }}
+        title: Modernize codebase
+        body: |
+          _This Pull Request was created automatically_
+        branch: modernize
+        labels: refactor
+        commit-message: Modernize codebase

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 !.github/workflows/check.yml
 !.github/workflows/codeql.yml
 !.github/workflows/gha.sum
+!.github/workflows/modernize.yml
 !.github/workflows/publish.yml
 !.github/workflows/semgrep.yml
 !.github/workflows/website.yml


### PR DESCRIPTION
Relates to #537

## Summary

Set up automated refactoring of the code base using the modernize tool in CI. This should keep the code base modern automatically over time.

The tool is not pinned or added as a `-tool` dependency following the tool's documentation (from [v0.20.0](https://pkg.go.dev/golang.org/x/tools/gopls@v0.20.0/internal/analysis/modernize), "Do not use "go get -tool" to add gopls as a dependency of your module; gopls commands must be built from their release branch.")