### PR TITLE
Skip explicit targets that are not YAML files

### DIFF
--- a/test/args.txtar
+++ b/test/args.txtar
@@ -48,6 +48,11 @@ stdout '[workflows]'
 stdout '[manifest/action.yml]'
 ! stderr .
 
+# Not a YAML file
+exec ades not_yaml.txt
+stdout 'Skipped'
+! stderr .
+
 # Conservative
 exec ades -conservative 'manifests/action.yml' 'workflows/.github/workflows/unsafe.yml'
 stdout 'Ok'
@@ -92,6 +97,8 @@ runs:
     run: echo 'Hello .yml'
   - name: Unsafe run
     run: echo 'Hello ${{ inputs.name }}'
+-- not_yaml.txt --
+Hello world!
 -- safe/.github/workflows/safe.yml --
 name: Example safe workflow
 on: [push]


### PR DESCRIPTION
Closes #620

## Summary

Update the CLI to skip any target given that is not a yaml file. This is safe because GitHub Actions does not consider any non-yml/yaml file as either a workflow or a manifest. This also aligns the behavior for explicit file targets with repository targets (the latter already skipped non-YAML files). To avoid confusion/misuse, the CLI does output that the target was skipped.