### PR TITLE
Update Go-based installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,18 @@ Fetch and run `ades` from source using the [Go] CLI:
 go run github.com/ericcornelissen/ades/cmd/ades@latest -version
 ```
 
-Or integrate it into a Go project as a tool (after which it can be run without `@latest`):
+Or fetch and install `ades` from source using the [Go] CLI, after which it can be run directly:
+
+```shell
+go install github.com/ericcornelissen/ades/cmd/ades@latest
+ades -version
+```
+
+Or integrate `ades` into a Go project as a tool, after which it can be run without `@latest`:
 
 ```shell
 go get -tool github.com/ericcornelissen/ades
+go run github.com/ericcornelissen/ades/cmd/ades -version
 ```
 
 [go]: https://go.dev/


### PR DESCRIPTION
Relates to #504, #523

## Summary

Add instructions for *installing* using the Go CLI and, accordingly, clarify how to run when installing as a Go `-tool`.