### PR TITLE
version bump

### DIFF
--- a/cmd/ades/main.go
+++ b/cmd/ades/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2025  Eric Cornelissen
+// Copyright (C) 2023-2026  Eric Cornelissen
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -397,7 +397,7 @@ func fix(report map[string]map[string][]ades.Violation) error {
 }
 
 func legal() {
-	fmt.Println(`ades  Copyright (C) 2025  Eric Cornelissen
+	fmt.Println(`ades  Copyright (C) 2026  Eric Cornelissen
 This program comes with ABSOLUTELY NO WARRANTY; see the GPL v3.0 for details.
 This is free software, and you are welcome to redistribute it under certain
 conditions; see the GPL v3.0 for details.`)
@@ -432,6 +432,6 @@ https://github.com/ericcornelissen/ades/issues/new/choose`)
 }
 
 func version() {
-	versionString := "v25.11"
+	versionString := "v26.01.0"
 	fmt.Println(versionString)
 }

--- a/tasks.go
+++ b/tasks.go
@@ -1,6 +1,6 @@
 // MIT No Attribution
 //
-// Copyright (c) 2024-2025 Eric Cornelissen
+// Copyright (c) 2024-2026 Eric Cornelissen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -334,9 +334,17 @@ func TaskRelease(t *T) error {
 		return err
 	}
 
+	var version string
+	for patch := 0; ; patch++ {
+		version = fmt.Sprintf(`v%s.%d`, date, patch)
+		if _, err := t.ExecS(`git rev-parse --quiet --verify refs/tags/` + version); err != nil {
+			break
+		}
+	}
+
 	err = t.Exec(
-		`sed -i cmd/ades/main.go -e 's/versionString := "v[0-9][0-9][.][0-9][0-9]"/versionString := "v`+date+`"/'`,
-		`sed -i test/flags-info.txtar -e "s/stdout 'v[0-9][0-9][.][0-9][0-9]'/stdout 'v`+date+`'/"`,
+		`sed -i cmd/ades/main.go -e 's/versionString := "v[0-9][0-9][.][0-9][0-9][.][0-9]*"/versionString := "`+version+`"/'`,
+		`sed -i test/flags-info.txtar -e "s/stdout 'v[0-9][0-9][.][0-9][0-9][.][0-9]*'/stdout '`+version+`'/"`,
 	)
 	if err != nil {
 		return err
@@ -359,8 +367,8 @@ func TaskRelease(t *T) error {
 	fmt.Println()
 	fmt.Println("    git checkout " + baseBranch)
 	fmt.Println("    git pull origin " + baseBranch)
-	fmt.Println("    git tag v" + date)
-	fmt.Println("    git push origin v" + date)
+	fmt.Println("    git tag " + version)
+	fmt.Println("    git push origin " + version)
 	fmt.Println()
 	fmt.Println("After that a release should be created automatically. If not, follow the release")
 	fmt.Println("guidelines in RELEASE.md.")

--- a/test/flags-info.txtar
+++ b/test/flags-info.txtar
@@ -10,12 +10,12 @@ cmp stdout $WORK/snapshots/legal-stdout.txt
 
 # Version
 exec ades -version
-stdout 'v25.11'
+stdout 'v26.01.0'
 ! stderr .
 
 
 -- snapshots/legal-stdout.txt --
-ades  Copyright (C) 2025  Eric Cornelissen
+ades  Copyright (C) 2026  Eric Cornelissen
 This program comes with ABSOLUTELY NO WARRANTY; see the GPL v3.0 for details.
 This is free software, and you are welcome to redistribute it under certain
 conditions; see the GPL v3.0 for details.


### PR DESCRIPTION
Relates to #129, #562

## Summary

Bump the version of this software from v25.11 to v26.01. Or, more specifically, to v26.01.0 as explained below.

Additionally, change the versioning strategy from `v<YY>.<MM>` to `v<YY>.<MM>.<PATCH>` where patch starts at 0. This embeds patch releases into the standard release tag name (rather than, informally, adding it in case an extra release is needed in the same month). Additionally, as this pattern matches SemVer versions it might trick the Go module system into accepting it as version tags.

The above has been implemented by modifying the `gask release` task.