### PR TITLE
refactor to use `appliesTo` of actionRule consistently

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -190,23 +190,15 @@ func analyzeStep(id int, step *gha.Step, matcher ExprMatcher) []Violation {
 		name = fmt.Sprintf("#%d", id)
 	}
 
-	rules := make([]rule, 0)
-	if uses := step.Uses; uses.Name != "" {
-		for _, r := range actionRules {
-			if r.appliesTo(&uses) {
-				rules = append(rules, r.rule)
-			}
-		}
-	} else {
-		for _, r := range stepRules {
-			if r.appliesTo(step) {
-				rules = append(rules, r.rule)
-			}
+	applicable := make([]rule, 0)
+	for _, r := range rules {
+		if r.appliesTo(step) {
+			applicable = append(applicable, r)
 		}
 	}
 
-	violations := make([][]Violation, len(rules))
-	for i, rule := range rules {
+	violations := make([][]Violation, len(applicable))
+	for i, rule := range applicable {
 		vs := analyzeString(rule.extractFrom(step), matcher)
 		for i := range vs {
 			vs[i].RuleId = rule.id

--- a/rules.go
+++ b/rules.go
@@ -25,21 +25,12 @@ import (
 )
 
 type rule struct {
+	appliesTo   func(step *gha.Step) bool
 	extractFrom func(step *gha.Step) string
 	fix         func(violation *Violation) []fix
 	id          string
 	title       string
 	description string
-}
-
-type actionRule struct {
-	appliesTo func(uses *gha.Uses) bool
-	rule      rule
-}
-
-type stepRule struct {
-	appliesTo func(step *gha.Step) bool
-	rule      rule
 }
 
 type fix struct {
@@ -50,14 +41,13 @@ type fix struct {
 	Old regexp.Regexp
 }
 
-var actionRule8398a7ActionSlack = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "8398a7/action-slack")
+var actionRule8398a7ActionSlack = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "8398a7/action-slack")
 	},
-	rule: rule{
-		id:    "ADES107",
-		title: "Expression in 'custom_payload' input of '8398a7/action-slack'",
-		description: `
+	id:    "ADES107",
+	title: "Expression in 'custom_payload' input of '8398a7/action-slack'",
+	description: `
 When an expression appears in the 'custom_payload' input of '8398a7/action-slack' you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
@@ -82,20 +72,19 @@ it can be made safer by converting it into:
       #                            ^^^^^^^^^^^^^^^^^
       #                            | Replace the expression with the environment variable
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["custom_payload"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["custom_payload"]
+
 	},
 }
 
-var actionRuleActionsGitHubScript = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "actions/github-script")
+var actionRuleActionsGitHubScript = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "actions/github-script")
 	},
-	rule: rule{
-		id:    "ADES101",
-		title: "Expression in 'actions/github-script' script",
-		description: `
+	id:    "ADES101",
+	title: "Expression in 'actions/github-script' script",
+	description: `
 When an expression appears in a 'actions/github-script' script you can avoid potential attacks by
 extracting the expression into an environment variable and using the environment variable instead.
 
@@ -119,20 +108,19 @@ it can be made safer by converting it into:
       #                     |
       #                     | Note: the use of backticks is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["script"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["script"]
+
 	},
 }
 
-var actionRuleAddnabDockerRunAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "addnab/docker-run-action")
+var actionRuleAddnabDockerRunAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "addnab/docker-run-action")
 	},
-	rule: rule{
-		id:    "ADES105",
-		title: "Expression in 'run' input of 'addnab/docker-run-action'",
-		description: `
+	id:    "ADES105",
+	title: "Expression in 'run' input of 'addnab/docker-run-action'",
+	description: `
 When an expression appears in the 'run' input of 'addnab/docker-run-action' you can avoid any
 potential attack by removing the expression. There is no safe way to use untrusted inputs here
 without risking injection.
@@ -140,20 +128,19 @@ without risking injection.
 Do NOT pass environment variables into the container through the action's options input. This opens
 up alternative attack vectors because the options are not validated.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["run"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["run"]
+
 	},
 }
 
-var actionRuleAmadevusPwshScript = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "Amadevus/pwsh-script")
+var actionRuleAmadevusPwshScript = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "Amadevus/pwsh-script")
 	},
-	rule: rule{
-		id:    "ADES110",
-		title: "Expression in 'script' input of 'Amadevus/pwsh-script'",
-		description: `
+	id:    "ADES110",
+	title: "Expression in 'script' input of 'Amadevus/pwsh-script'",
+	description: `
 When an expression appears in the 'script' input of 'Amadevus/pwsh-script' you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
@@ -180,20 +167,19 @@ it can be made safer by converting it into:
       #                |
       #                | Note: the use of double quotes is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["script"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["script"]
+
 	},
 }
 
-var actionRuleAppleboySshAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "appleboy/ssh-action")
+var actionRuleAppleboySshAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "appleboy/ssh-action")
 	},
-	rule: rule{
-		id:    "ADES108",
-		title: "Expression in 'script' input of 'appleboy/ssh-action'",
-		description: `
+	id:    "ADES108",
+	title: "Expression in 'script' input of 'appleboy/ssh-action'",
+	description: `
 When an expression appears in the 'script' input of 'appleboy/ssh-action' you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
@@ -219,42 +205,40 @@ it can be made safer by converting it into:
       #              |
       #              | Note: the use of double quotes is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["script"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["script"]
+
 	},
 }
 
-var actionRuleAtlassianGajiraCreate = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "atlassian/gajira-create") {
+var actionRuleAtlassianGajiraCreate = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "atlassian/gajira-create") {
 			return false
 		}
 
-		return isBeforeVersion(uses, "v2.0.1")
+		return isBeforeVersion(step, "v2.0.1")
 	},
-	rule: rule{
-		id:    "ADES202",
-		title: "Expression in 'summary' input of 'atlassian/gajira-create'",
-		description: `
+	id:    "ADES202",
+	title: "Expression in 'summary' input of 'atlassian/gajira-create'",
+	description: `
 When an expression is used in the 'summary' input of 'atlassian/gajira-create' in v2.0.0 or earlier
 it may be used to execute arbitrary JavaScript code, see GHSA-4xqx-pqpj-9fqw. To mitigate this,
 upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["summary"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["summary"]
+
 	},
 }
 
-var actionRuleAzureCli = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "azure/cli")
+var actionRuleAzureCli = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "azure/cli")
 	},
-	rule: rule{
-		id:    "ADES115",
-		title: "Expression in 'inlineScript' input of 'azure/cli'",
-		description: `
+	id:    "ADES115",
+	title: "Expression in 'inlineScript' input of 'azure/cli'",
+	description: `
 When an expression appears in the 'inlineScript' input of 'azure/cli' you can avoid any potential
 attack by extracting the expression into an environment variable and using the environment variable
 instead.
@@ -281,20 +265,19 @@ it can be made safer by converting it into:
       #                      |
       #                      | Note: the use of double quotes is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["inlineScript"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["inlineScript"]
+
 	},
 }
 
-var actionRuleAzurePowershell = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "azure/powershell")
+var actionRuleAzurePowershell = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "azure/powershell")
 	},
-	rule: rule{
-		id:    "ADES113",
-		title: "Expression in 'inlineScript' input of 'azure/powershell'",
-		description: `
+	id:    "ADES113",
+	title: "Expression in 'inlineScript' input of 'azure/powershell'",
+	description: `
 When an expression appears in the 'inlineScript' input of 'azure/powershell' you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
@@ -323,20 +306,19 @@ it can be made safer by converting it into:
       #                |
       #                | Note: the use of double quotes is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["inlineScript"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["inlineScript"]
+
 	},
 }
 
-var actionRuleCardinalbyJsEvalAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "cardinalby/js-eval-action")
+var actionRuleCardinalbyJsEvalAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "cardinalby/js-eval-action")
 	},
-	rule: rule{
-		id:    "ADES106",
-		title: "Expression in 'expression' input of 'cardinalby/js-eval-action'",
-		description: `
+	id:    "ADES106",
+	title: "Expression in 'expression' input of 'cardinalby/js-eval-action'",
+	description: `
 When an expression appears in the 'expression' input of 'cardinalby/js-eval-action' you can avoid
 any potential attack by extracting the expression into an environment variable and using the
 environment variable instead.
@@ -359,43 +341,41 @@ it can be made safer by converting it into:
       #                          ^^^^^^^^^
       #                          | Replace the expression with the environment variable
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["expression"]
-		},
-		fix: func(violation *Violation) []fix {
-			var step gha.Step
-			switch source := (violation.source).(type) {
-			case *gha.Manifest:
-				step = source.Runs.Steps[violation.stepIndex]
-			case *gha.Workflow:
-				step = source.Jobs[violation.jobKey].Steps[violation.stepIndex]
-			}
+	extractFrom: func(step *gha.Step) string {
+		return step.With["expression"]
+	},
+	fix: func(violation *Violation) []fix {
+		var step gha.Step
+		switch source := (violation.source).(type) {
+		case *gha.Manifest:
+			step = source.Runs.Steps[violation.stepIndex]
+		case *gha.Workflow:
+			step = source.Jobs[violation.jobKey].Steps[violation.stepIndex]
+		}
 
-			name := getVariableNameForExpression(violation.Problem)
-			if _, ok := step.Env[name]; ok {
-				return nil
-			}
+		name := getVariableNameForExpression(violation.Problem)
+		if _, ok := step.Env[name]; ok {
+			return nil
+		}
 
-			fixes := fixAddEnvVar(step, name, violation.Problem)
-			fixes = append(fixes, fixReplaceIn(
-				step.With["expression"],
-				violation.Problem,
-				"env."+name,
-			))
+		fixes := fixAddEnvVar(step, name, violation.Problem)
+		fixes = append(fixes, fixReplaceIn(
+			step.With["expression"],
+			violation.Problem,
+			"env."+name,
+		))
 
-			return fixes
-		},
+		return fixes
 	},
 }
 
-var actionRuleDevorbitusYqActionOutput = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "devorbitus/yq-action-output")
+var actionRuleDevorbitusYqActionOutput = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "devorbitus/yq-action-output")
 	},
-	rule: rule{
-		id:    "ADES112",
-		title: "Expression in 'cmd' input of 'devorbitus/yq-action-output'",
-		description: `
+	id:    "ADES112",
+	title: "Expression in 'cmd' input of 'devorbitus/yq-action-output'",
+	description: `
 When an expression appears in the 'cmd' input of 'devorbitus/yq-action-output' you can avoid any
 potential attack by extracting the expression into an environment variable and using the environment
 variable instead.
@@ -420,65 +400,62 @@ it can be made safer by converting it into:
       #             |
       #             | Note: the use of double quotes is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["cmd"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["cmd"]
+
 	},
 }
 
-var actionRuleEriccornelissenGitTagAnnotationAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "ericcornelissen/git-tag-annotation-action") {
+var actionRuleEriccornelissenGitTagAnnotationAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "ericcornelissen/git-tag-annotation-action") {
 			return false
 		}
 
-		return isBeforeVersion(uses, "v1.0.1")
+		return isBeforeVersion(step, "v1.0.1")
 
 	},
-	rule: rule{
-		id:    "ADES200",
-		title: "Expression in 'tag' input of 'ericcornelissen/git-tag-annotation-action'",
-		description: `
+	id:    "ADES200",
+	title: "Expression in 'tag' input of 'ericcornelissen/git-tag-annotation-action'",
+	description: `
 When an expression is used in the 'tag' input of 'ericcornelissen/git-tag-annotation-action' in
 v1.0.0 or earlier it may be used to execute arbitrary shell commands, see GHSA-hgx2-4pp9-357g. To
 mitigate this, upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["tag"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["tag"]
+
 	},
 }
 
-var actionRuleFishShopSyntaxCheck = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "fish-shop/syntax-check") {
+var actionRuleFishShopSyntaxCheck = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "fish-shop/syntax-check") {
 			return false
 		}
 
-		return isBeforeVersion(uses, "v1.6.12")
+		return isBeforeVersion(step, "v1.6.12")
 	},
-	rule: rule{
-		id:    "ADES206",
-		title: "Expression in 'pattern' input of 'fish-shop/syntax-check'",
-		description: `
+	id:    "ADES206",
+	title: "Expression in 'pattern' input of 'fish-shop/syntax-check'",
+	description: `
 When an expression is used in the 'pattern' input of 'fish-shop/syntax-check' in v1.6.11 or earlier
 it may be used to execute arbitrary shell commands, see GHSA-xj87-mqvh-88w2. To mitigate this,
 upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["pattern"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["pattern"]
+
 	},
 }
 
-var actionRuleGautamkrishnarBlogPostWorkflow = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "gautamkrishnar/blog-post-workflow")
+var actionRuleGautamkrishnarBlogPostWorkflow = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "gautamkrishnar/blog-post-workflow")
 	},
-	rule: rule{
-		id:    "ADES114",
-		title: "Expression in 'item_exec' input of 'gautamkrishnar/blog-post-workflow'",
-		description: `
+	id:    "ADES114",
+	title: "Expression in 'item_exec' input of 'gautamkrishnar/blog-post-workflow'",
+	description: `
 When an expression appears in the 'item_exec' input of 'gautamkrishnar/blog-post-workflow' you can
 avoid any potential attack by extracting the expression into an environment variable and using the
 environment variable instead.
@@ -507,20 +484,19 @@ it can be made safer by converting it into:
       #                |
       #                | Note: the use of backticks is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["item_exec"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["item_exec"]
+
 	},
 }
 
-var actionRuleJannekemRunPythonScriptAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "jannekem/run-python-script-action")
+var actionRuleJannekemRunPythonScriptAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "jannekem/run-python-script-action")
 	},
-	rule: rule{
-		id:    "ADES109",
-		title: "Expression in 'script' input of 'jannekem/run-python-script-action'",
-		description: `
+	id:    "ADES109",
+	title: "Expression in 'script' input of 'jannekem/run-python-script-action'",
+	description: `
 When an expression appears in the 'script' input of 'jannekem/run-python-script-action' you can
 avoid any potential attack by extracting the expression into an environment variable and using the
 environment variable instead.
@@ -545,64 +521,61 @@ it can be made safer by converting it into:
       #               |
       #               | Note: the use of string interpolation is required in this example
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["script"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["script"]
+
 	},
 }
 
-var actionRuleKcebGitMessageAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "kceb/git-message-action") {
+var actionRuleKcebGitMessageAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "kceb/git-message-action") {
 			return false
 		}
 
-		return isBeforeVersion(uses, "v1.2.0")
+		return isBeforeVersion(step, "v1.2.0")
 	},
-	rule: rule{
-		id:    "ADES201",
-		title: "Expression in 'sha' input of 'kceb/git-message-action'",
-		description: `
+	id:    "ADES201",
+	title: "Expression in 'sha' input of 'kceb/git-message-action'",
+	description: `
 When an expression is used in the 'sha' input of 'kceb/git-message-action' in v1.1.0 or earlier it
 may be used to execute arbitrary shell commands (no vulnerability identifier available). To mitigate
 this, upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["sha"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["sha"]
+
 	},
 }
 
-var actionRuleLycheeverseLycheeAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "lycheeverse/lychee") {
+var actionRuleLycheeverseLycheeAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "lycheeverse/lychee") {
 			return false
 		}
 
-		return isBeforeVersion(uses, "v2.0.2")
+		return isBeforeVersion(step, "v2.0.2")
 	},
-	rule: rule{
-		id:    "ADES204",
-		title: "Expression in 'lycheeVersion' input of 'lycheeverse/lychee'",
-		description: `
+	id:    "ADES204",
+	title: "Expression in 'lycheeVersion' input of 'lycheeverse/lychee'",
+	description: `
 When an expression is used in the 'lycheeVersion' input of 'lycheeverse/lychee' in v2.0.1 or earlier
 it may be used to execute arbitrary shell commands, see GHSA-65rg-554r-9j5x. To mitigate this,
 upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["lycheeVersion"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["lycheeVersion"]
+
 	},
 }
 
-var actionRuleMikefarahYq = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "mikefarah/yq")
+var actionRuleMikefarahYq = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "mikefarah/yq")
 	},
-	rule: rule{
-		id:    "ADES111",
-		title: "Expression in 'cmd' input of 'mikefarah/yq'",
-		description: `
+	id:    "ADES111",
+	title: "Expression in 'cmd' input of 'mikefarah/yq'",
+	description: `
 When an expression appears in the 'cmd' input of 'mikefarah/yq' you can avoid any potential attack
 by extracting the expression into an environment variable and using the environment variable
 instead.
@@ -627,42 +600,40 @@ it can be made safer by converting it into:
       #        |
       #        | Note: the use of double quotes is required in this example (for interpolation)
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["cmd"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["cmd"]
+
 	},
 }
 
-var actionRuleOziProjectPublish = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "OZI-Project/publish") {
+var actionRuleOziProjectPublish = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "OZI-Project/publish") {
 			return false
 		}
 
-		return isAtOrAfterVersion(uses, "v1.13.2") && isBeforeVersion(uses, "v1.13.6")
+		return isAtOrAfterVersion(step, "v1.13.2") && isBeforeVersion(step, "v1.13.6")
 	},
-	rule: rule{
-		id:    "ADES205",
-		title: "Expression in 'pull-request-body' input of 'OZI-Project/publish'",
-		description: `
+	id:    "ADES205",
+	title: "Expression in 'pull-request-body' input of 'OZI-Project/publish'",
+	description: `
 When an expression is used in the 'pull-request-body' input of 'OZI-Project/publish' between v1.13.2
 and v1.13.5 it may be used to execute arbitrary shell commands, see GHSA-2487-9f55-2vg9. To mitigate
 this, upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["pull-request-body"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["pull-request-body"]
+
 	},
 }
 
-var actionRuleRootsIssueCloserActionIssueCloseMessage = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "roots/issue-closer") || hasName(uses, "roots/issue-closer-action")
+var actionRuleRootsIssueCloserActionIssueCloseMessage = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "roots/issue-closer") || hasName(step, "roots/issue-closer-action")
 	},
-	rule: rule{
-		id:    "ADES102",
-		title: "Expression in 'issue-close-message' input of 'roots/issue-closer-action'",
-		description: `
+	id:    "ADES102",
+	title: "Expression in 'issue-close-message' input of 'roots/issue-closer-action'",
+	description: `
 When an expression appears in the 'issue-close-message' input of 'roots/issue-closer-action' it is
 interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
@@ -685,43 +656,41 @@ it can be made safer by converting it into:
       #                              ^^^^^^^^^^^^^^^^^^^
       #                              | Replace the expression with the environment variable
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["issue-close-message"]
-		},
-		fix: func(violation *Violation) []fix {
-			var step gha.Step
-			switch source := (violation.source).(type) {
-			case *gha.Manifest:
-				step = source.Runs.Steps[violation.stepIndex]
-			case *gha.Workflow:
-				step = source.Jobs[violation.jobKey].Steps[violation.stepIndex]
-			}
+	extractFrom: func(step *gha.Step) string {
+		return step.With["issue-close-message"]
+	},
+	fix: func(violation *Violation) []fix {
+		var step gha.Step
+		switch source := (violation.source).(type) {
+		case *gha.Manifest:
+			step = source.Runs.Steps[violation.stepIndex]
+		case *gha.Workflow:
+			step = source.Jobs[violation.jobKey].Steps[violation.stepIndex]
+		}
 
-			name := getVariableNameForExpression(violation.Problem)
-			if _, ok := step.Env[name]; ok {
-				return nil
-			}
+		name := getVariableNameForExpression(violation.Problem)
+		if _, ok := step.Env[name]; ok {
+			return nil
+		}
 
-			fixes := fixAddEnvVar(step, name, violation.Problem)
-			fixes = append(fixes, fixReplaceIn(
-				step.With["issue-close-message"],
-				violation.Problem,
-				fmt.Sprintf("${process.env.%s}", name),
-			))
+		fixes := fixAddEnvVar(step, name, violation.Problem)
+		fixes = append(fixes, fixReplaceIn(
+			step.With["issue-close-message"],
+			violation.Problem,
+			fmt.Sprintf("${process.env.%s}", name),
+		))
 
-			return fixes
-		},
+		return fixes
 	},
 }
 
-var actionRuleRootsIssueCloserActionPrCloseMessage = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return actionRuleRootsIssueCloserActionIssueCloseMessage.appliesTo(uses)
+var actionRuleRootsIssueCloserActionPrCloseMessage = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return actionRuleRootsIssueCloserActionIssueCloseMessage.appliesTo(step)
 	},
-	rule: rule{
-		id:    "ADES103",
-		title: "Expression in 'pr-close-message' input of 'roots/issue-closer-action'",
-		description: `
+	id:    "ADES103",
+	title: "Expression in 'pr-close-message' input of 'roots/issue-closer-action'",
+	description: `
 When an expression appears in the 'pr-close-message' input of 'roots/issue-closer-action' it is
 interpreted as an ES6-style template literal. You can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
@@ -744,20 +713,19 @@ it can be made safer by converting it into:
       #                           ^^^^^^^^^^^^^^^^^^^
       #                           | Replace the expression with the environment variable
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["pr-close-message"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["pr-close-message"]
+
 	},
 }
 
-var actionRuleSergeysovaJqAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		return hasName(uses, "sergeysova/jq-action")
+var actionRuleSergeysovaJqAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		return hasName(step, "sergeysova/jq-action")
 	},
-	rule: rule{
-		id:    "ADES104",
-		title: "Expression in 'cmd' input of 'sergeysova/jq-action'",
-		description: `
+	id:    "ADES104",
+	title: "Expression in 'cmd' input of 'sergeysova/jq-action'",
+	description: `
 When an expression appears in the 'cmd' input of 'sergeysova/jq-action' you can avoid any potential
 attack by extracting the expression into an environment variable and using the environment variable
 instead.
@@ -782,67 +750,40 @@ it can be made safer by converting it into:
       #                 |
       #                 | Note: use double quotes to avoid argument splitting
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["cmd"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["cmd"]
+
 	},
 }
 
-var actionRuleSonarSourceSonarqubeScanAction = actionRule{
-	appliesTo: func(uses *gha.Uses) bool {
-		if !hasName(uses, "SonarSource/sonarqube-scan-action") {
+var actionRuleSonarSourceSonarqubeScanAction = rule{
+	appliesTo: func(step *gha.Step) bool {
+		if !hasName(step, "SonarSource/sonarqube-scan-action") {
 			return false
 		}
 
-		return isAtOrAfterVersion(uses, "v4.0.0") && isBeforeVersion(uses, "v5.3.1")
+		return isAtOrAfterVersion(step, "v4.0.0") && isBeforeVersion(step, "v5.3.1")
 	},
-	rule: rule{
-		id:    "ADES203",
-		title: "Expression in 'args' input of 'SonarSource/sonarqube-scan-action'",
-		description: `
+	id:    "ADES203",
+	title: "Expression in 'args' input of 'SonarSource/sonarqube-scan-action'",
+	description: `
 When an expression is used in the 'args' input of 'SonarSource/sonarqube-scan-action' between v4.0.0
 and v5.3.0 it may be used to execute arbitrary shell commands, see GHSA-f79p-9c5r-xg88. To mitigate
 this, upgrade the action to a non-vulnerable version.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.With["args"]
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.With["args"]
+
 	},
 }
 
-var actionRules = []actionRule{
-	actionRule8398a7ActionSlack,
-	actionRuleActionsGitHubScript,
-	actionRuleAddnabDockerRunAction,
-	actionRuleAppleboySshAction,
-	actionRuleAmadevusPwshScript,
-	actionRuleAtlassianGajiraCreate,
-	actionRuleAzureCli,
-	actionRuleAzurePowershell,
-	actionRuleCardinalbyJsEvalAction,
-	actionRuleDevorbitusYqActionOutput,
-	actionRuleEriccornelissenGitTagAnnotationAction,
-	actionRuleFishShopSyntaxCheck,
-	actionRuleGautamkrishnarBlogPostWorkflow,
-	actionRuleJannekemRunPythonScriptAction,
-	actionRuleKcebGitMessageAction,
-	actionRuleLycheeverseLycheeAction,
-	actionRuleMikefarahYq,
-	actionRuleOziProjectPublish,
-	actionRuleRootsIssueCloserActionIssueCloseMessage,
-	actionRuleRootsIssueCloserActionPrCloseMessage,
-	actionRuleSergeysovaJqAction,
-	actionRuleSonarSourceSonarqubeScanAction,
-}
-
-var stepRuleRun = stepRule{
+var stepRuleRun = rule{
 	appliesTo: func(step *gha.Step) bool {
 		return len(step.Run) > 0
 	},
-	rule: rule{
-		id:    "ADES100",
-		title: "Expression in 'run:' directive",
-		description: `
+	id:    "ADES100",
+	title: "Expression in 'run:' directive",
+	description: `
 When an expression appears in a 'run:' directive you can avoid potential attacks by extracting the
 expression into an environment variable and using the environment variable instead.
 
@@ -867,34 +808,56 @@ it can be made safer by converting it into:
 Note that the changes depend on the runner and shell being used. For example, on Windows (or when
 using 'shell: powershell') the environment variable must be accessed as '$Env:NAME'.
 `,
-		extractFrom: func(step *gha.Step) string {
-			return step.Run
-		},
+	extractFrom: func(step *gha.Step) string {
+		return step.Run
+
 	},
 }
 
-var stepRules = []stepRule{
+var rules = []rule{
+	actionRule8398a7ActionSlack,
+	actionRuleActionsGitHubScript,
+	actionRuleAddnabDockerRunAction,
+	actionRuleAppleboySshAction,
+	actionRuleAmadevusPwshScript,
+	actionRuleAtlassianGajiraCreate,
+	actionRuleAzureCli,
+	actionRuleAzurePowershell,
+	actionRuleCardinalbyJsEvalAction,
+	actionRuleDevorbitusYqActionOutput,
+	actionRuleEriccornelissenGitTagAnnotationAction,
+	actionRuleFishShopSyntaxCheck,
+	actionRuleGautamkrishnarBlogPostWorkflow,
+	actionRuleJannekemRunPythonScriptAction,
+	actionRuleKcebGitMessageAction,
+	actionRuleLycheeverseLycheeAction,
+	actionRuleMikefarahYq,
+	actionRuleOziProjectPublish,
+	actionRuleRootsIssueCloserActionIssueCloseMessage,
+	actionRuleRootsIssueCloserActionPrCloseMessage,
+	actionRuleSergeysovaJqAction,
+	actionRuleSonarSourceSonarqubeScanAction,
 	stepRuleRun,
 }
 
-func getRef(uses *gha.Uses) (string, bool) {
-	ref := uses.Ref
-	if !semver.IsValid(ref) {
-		ref = uses.Annotation
-		if !semver.IsValid(ref) {
-			return "", false
-		}
+func getRef(step *gha.Step) (string, bool) {
+	if ref := step.Uses.Ref; semver.IsValid(ref) {
+		return ref, true
 	}
 
-	return ref, true
+	if ref := step.Uses.Annotation; semver.IsValid(ref) {
+		return ref, true
+	}
+
+	return "", false
 }
 
-func hasName(uses *gha.Uses, name string) bool {
-	return strings.EqualFold(uses.Name, name)
+func hasName(step *gha.Step, name string) bool {
+	return strings.EqualFold(step.Uses.Name, name)
 }
 
-func isAtOrAfterVersion(uses *gha.Uses, version string) bool {
-	ref, ok := getRef(uses)
+func isAtOrAfterVersion(step *gha.Step, version string) bool {
+	ref, ok := getRef(step)
 	if !ok {
 		return false
 	}
@@ -909,8 +872,8 @@ func isAtOrAfterVersion(uses *gha.Uses, version string) bool {
 	}
 }
 
-func isBeforeVersion(uses *gha.Uses, version string) bool {
-	ref, ok := getRef(uses)
+func isBeforeVersion(step *gha.Step, version string) bool {
+	ref, ok := getRef(step)
 	if !ok {
 		return false
 	}
@@ -954,15 +917,9 @@ func Fix(violation *Violation) ([]fix, error) {
 
 func findRule(ruleId string) (rule, error) {
 	ruleId = strings.ToUpper(ruleId)
-	for _, r := range actionRules {
-		if r.rule.id == ruleId {
-			return r.rule, nil
-		}
-	}
-
-	for _, r := range stepRules {
-		if r.rule.id == ruleId {
-			return r.rule, nil
+	for _, rule := range rules {
+		if rule.id == ruleId {
+			return rule, nil
 		}
 	}
 

--- a/rules_test.go
+++ b/rules_test.go
@@ -28,9 +28,9 @@ import (
 
 func TestActionRule8398a7ActionSlack(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "8398a7/action-slack"
-			return actionRule8398a7ActionSlack.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "8398a7/action-slack"
+			return actionRule8398a7ActionSlack.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -41,7 +41,7 @@ func TestActionRule8398a7ActionSlack(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["custom_payload"] = value
-			return actionRule8398a7ActionSlack.rule.extractFrom(&step) == value
+			return actionRule8398a7ActionSlack.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -49,7 +49,7 @@ func TestActionRule8398a7ActionSlack(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "custom_payload")
-			return actionRule8398a7ActionSlack.rule.extractFrom(&step) == ""
+			return actionRule8398a7ActionSlack.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -59,9 +59,9 @@ func TestActionRule8398a7ActionSlack(t *testing.T) {
 
 func TestActionRuleActionsGithubScript(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "actions/github-script"
-			return actionRuleActionsGitHubScript.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "actions/github-script"
+			return actionRuleActionsGitHubScript.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -72,7 +72,7 @@ func TestActionRuleActionsGithubScript(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["script"] = value
-			return actionRuleActionsGitHubScript.rule.extractFrom(&step) == value
+			return actionRuleActionsGitHubScript.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -80,7 +80,7 @@ func TestActionRuleActionsGithubScript(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "script")
-			return actionRuleActionsGitHubScript.rule.extractFrom(&step) == ""
+			return actionRuleActionsGitHubScript.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -90,9 +90,9 @@ func TestActionRuleActionsGithubScript(t *testing.T) {
 
 func TestActionRuleAddnabDockerRunAction(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "addnab/docker-run-action"
-			return actionRuleAddnabDockerRunAction.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "addnab/docker-run-action"
+			return actionRuleAddnabDockerRunAction.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -103,7 +103,7 @@ func TestActionRuleAddnabDockerRunAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["run"] = value
-			return actionRuleAddnabDockerRunAction.rule.extractFrom(&step) == value
+			return actionRuleAddnabDockerRunAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -111,7 +111,7 @@ func TestActionRuleAddnabDockerRunAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "run")
-			return actionRuleAddnabDockerRunAction.rule.extractFrom(&step) == ""
+			return actionRuleAddnabDockerRunAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -121,9 +121,9 @@ func TestActionRuleAddnabDockerRunAction(t *testing.T) {
 
 func TestActionRuleAmadevusPwshScript(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "Amadevus/pwsh-script"
-			return actionRuleAmadevusPwshScript.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "Amadevus/pwsh-script"
+			return actionRuleAmadevusPwshScript.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -134,7 +134,7 @@ func TestActionRuleAmadevusPwshScript(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["script"] = value
-			return actionRuleAmadevusPwshScript.rule.extractFrom(&step) == value
+			return actionRuleAmadevusPwshScript.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -142,7 +142,7 @@ func TestActionRuleAmadevusPwshScript(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "script")
-			return actionRuleAmadevusPwshScript.rule.extractFrom(&step) == ""
+			return actionRuleAmadevusPwshScript.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -152,9 +152,9 @@ func TestActionRuleAmadevusPwshScript(t *testing.T) {
 
 func TestActionRuleAppleboySshAction(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "appleboy/ssh-action"
-			return actionRuleAppleboySshAction.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "appleboy/ssh-action"
+			return actionRuleAppleboySshAction.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -165,7 +165,7 @@ func TestActionRuleAppleboySshAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["script"] = value
-			return actionRuleAppleboySshAction.rule.extractFrom(&step) == value
+			return actionRuleAppleboySshAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -173,7 +173,7 @@ func TestActionRuleAppleboySshAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "script")
-			return actionRuleAppleboySshAction.rule.extractFrom(&step) == ""
+			return actionRuleAppleboySshAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -211,12 +211,14 @@ func TestActionRuleAtlassianGajiraCreate(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "atlassian/gajira-create",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "atlassian/gajira-create",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleAtlassianGajiraCreate.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleAtlassianGajiraCreate.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -226,7 +228,7 @@ func TestActionRuleAtlassianGajiraCreate(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["summary"] = value
-			return actionRuleAtlassianGajiraCreate.rule.extractFrom(&step) == value
+			return actionRuleAtlassianGajiraCreate.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -234,7 +236,7 @@ func TestActionRuleAtlassianGajiraCreate(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "summary")
-			return actionRuleAtlassianGajiraCreate.rule.extractFrom(&step) == ""
+			return actionRuleAtlassianGajiraCreate.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -244,9 +246,9 @@ func TestActionRuleAtlassianGajiraCreate(t *testing.T) {
 
 func TestActionRuleAzureCli(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "azure/cli"
-			return actionRuleAzureCli.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "azure/cli"
+			return actionRuleAzureCli.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -257,7 +259,7 @@ func TestActionRuleAzureCli(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["inlineScript"] = value
-			return actionRuleAzureCli.rule.extractFrom(&step) == value
+			return actionRuleAzureCli.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -265,7 +267,7 @@ func TestActionRuleAzureCli(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "inlineScript")
-			return actionRuleAzureCli.rule.extractFrom(&step) == ""
+			return actionRuleAzureCli.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -275,9 +277,9 @@ func TestActionRuleAzureCli(t *testing.T) {
 
 func TestActionRuleAzurePowershell(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "azure/powershell"
-			return actionRuleAzurePowershell.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "azure/powershell"
+			return actionRuleAzurePowershell.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -288,7 +290,7 @@ func TestActionRuleAzurePowershell(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["inlineScript"] = value
-			return actionRuleAzurePowershell.rule.extractFrom(&step) == value
+			return actionRuleAzurePowershell.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -296,7 +298,7 @@ func TestActionRuleAzurePowershell(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "inlineScript")
-			return actionRuleAzurePowershell.rule.extractFrom(&step) == ""
+			return actionRuleAzurePowershell.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -306,9 +308,9 @@ func TestActionRuleAzurePowershell(t *testing.T) {
 
 func TestActionRuleCardinalbyJsEvalAction(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "cardinalby/js-eval-action"
-			return actionRuleCardinalbyJsEvalAction.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "cardinalby/js-eval-action"
+			return actionRuleCardinalbyJsEvalAction.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -319,7 +321,7 @@ func TestActionRuleCardinalbyJsEvalAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["expression"] = value
-			return actionRuleCardinalbyJsEvalAction.rule.extractFrom(&step) == value
+			return actionRuleCardinalbyJsEvalAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -327,7 +329,7 @@ func TestActionRuleCardinalbyJsEvalAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "expression")
-			return actionRuleCardinalbyJsEvalAction.rule.extractFrom(&step) == ""
+			return actionRuleCardinalbyJsEvalAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -337,9 +339,9 @@ func TestActionRuleCardinalbyJsEvalAction(t *testing.T) {
 
 func TestActionRuleDevorbitusYqActionOutput(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "devorbitus/yq-action-output"
-			return actionRuleDevorbitusYqActionOutput.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "devorbitus/yq-action-output"
+			return actionRuleDevorbitusYqActionOutput.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -350,7 +352,7 @@ func TestActionRuleDevorbitusYqActionOutput(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["cmd"] = value
-			return actionRuleDevorbitusYqActionOutput.rule.extractFrom(&step) == value
+			return actionRuleDevorbitusYqActionOutput.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -358,7 +360,7 @@ func TestActionRuleDevorbitusYqActionOutput(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "cmd")
-			return actionRuleDevorbitusYqActionOutput.rule.extractFrom(&step) == ""
+			return actionRuleDevorbitusYqActionOutput.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -396,12 +398,14 @@ func TestActionRuleEriccornelissenGitTagAnnotationAction(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "ericcornelissen/git-tag-annotation-action",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "ericcornelissen/git-tag-annotation-action",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleEriccornelissenGitTagAnnotationAction.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleEriccornelissenGitTagAnnotationAction.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -411,7 +415,7 @@ func TestActionRuleEriccornelissenGitTagAnnotationAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["tag"] = value
-			return actionRuleEriccornelissenGitTagAnnotationAction.rule.extractFrom(&step) == value
+			return actionRuleEriccornelissenGitTagAnnotationAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -419,7 +423,7 @@ func TestActionRuleEriccornelissenGitTagAnnotationAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "tag")
-			return actionRuleEriccornelissenGitTagAnnotationAction.rule.extractFrom(&step) == ""
+			return actionRuleEriccornelissenGitTagAnnotationAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -457,12 +461,14 @@ func TestActionRuleFishShopSyntaxCheck(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "fish-shop/syntax-check",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "fish-shop/syntax-check",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleFishShopSyntaxCheck.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleFishShopSyntaxCheck.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -472,7 +478,7 @@ func TestActionRuleFishShopSyntaxCheck(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["pattern"] = value
-			return actionRuleFishShopSyntaxCheck.rule.extractFrom(&step) == value
+			return actionRuleFishShopSyntaxCheck.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -480,7 +486,7 @@ func TestActionRuleFishShopSyntaxCheck(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "pattern")
-			return actionRuleFishShopSyntaxCheck.rule.extractFrom(&step) == ""
+			return actionRuleFishShopSyntaxCheck.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -490,9 +496,9 @@ func TestActionRuleFishShopSyntaxCheck(t *testing.T) {
 
 func TestActionRuleGautamkrishnarBlogPostWorkflow(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "gautamkrishnar/blog-post-workflow"
-			return actionRuleGautamkrishnarBlogPostWorkflow.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "gautamkrishnar/blog-post-workflow"
+			return actionRuleGautamkrishnarBlogPostWorkflow.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -503,7 +509,7 @@ func TestActionRuleGautamkrishnarBlogPostWorkflow(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["item_exec"] = value
-			return actionRuleGautamkrishnarBlogPostWorkflow.rule.extractFrom(&step) == value
+			return actionRuleGautamkrishnarBlogPostWorkflow.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -511,7 +517,7 @@ func TestActionRuleGautamkrishnarBlogPostWorkflow(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "item_exec")
-			return actionRuleGautamkrishnarBlogPostWorkflow.rule.extractFrom(&step) == ""
+			return actionRuleGautamkrishnarBlogPostWorkflow.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -521,9 +527,9 @@ func TestActionRuleGautamkrishnarBlogPostWorkflow(t *testing.T) {
 
 func TestActionRuleJannekemRunPythonScriptAction(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "jannekem/run-python-script-action"
-			return actionRuleJannekemRunPythonScriptAction.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "jannekem/run-python-script-action"
+			return actionRuleJannekemRunPythonScriptAction.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -534,7 +540,7 @@ func TestActionRuleJannekemRunPythonScriptAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["script"] = value
-			return actionRuleJannekemRunPythonScriptAction.rule.extractFrom(&step) == value
+			return actionRuleJannekemRunPythonScriptAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -542,7 +548,7 @@ func TestActionRuleJannekemRunPythonScriptAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "script")
-			return actionRuleJannekemRunPythonScriptAction.rule.extractFrom(&step) == ""
+			return actionRuleJannekemRunPythonScriptAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -580,12 +586,14 @@ func TestActionRuleKcebGitMessageAction(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "kceb/git-message-action",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "kceb/git-message-action",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleKcebGitMessageAction.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleKcebGitMessageAction.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -595,7 +603,7 @@ func TestActionRuleKcebGitMessageAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["sha"] = value
-			return actionRuleKcebGitMessageAction.rule.extractFrom(&step) == value
+			return actionRuleKcebGitMessageAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -603,7 +611,7 @@ func TestActionRuleKcebGitMessageAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "sha")
-			return actionRuleKcebGitMessageAction.rule.extractFrom(&step) == ""
+			return actionRuleKcebGitMessageAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -641,12 +649,14 @@ func TestActionRuleLycheeverseLycheeAction(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "lycheeverse/lychee",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "lycheeverse/lychee",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleLycheeverseLycheeAction.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleLycheeverseLycheeAction.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -656,7 +666,7 @@ func TestActionRuleLycheeverseLycheeAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["lycheeVersion"] = value
-			return actionRuleLycheeverseLycheeAction.rule.extractFrom(&step) == value
+			return actionRuleLycheeverseLycheeAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -664,7 +674,7 @@ func TestActionRuleLycheeverseLycheeAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "lycheeVersion")
-			return actionRuleLycheeverseLycheeAction.rule.extractFrom(&step) == ""
+			return actionRuleLycheeverseLycheeAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -674,9 +684,9 @@ func TestActionRuleLycheeverseLycheeAction(t *testing.T) {
 
 func TestActionRuleMikefarahYq(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "mikefarah/yq"
-			return actionRuleMikefarahYq.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "mikefarah/yq"
+			return actionRuleMikefarahYq.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -687,7 +697,7 @@ func TestActionRuleMikefarahYq(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["cmd"] = value
-			return actionRuleMikefarahYq.rule.extractFrom(&step) == value
+			return actionRuleMikefarahYq.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -695,7 +705,7 @@ func TestActionRuleMikefarahYq(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "cmd")
-			return actionRuleMikefarahYq.rule.extractFrom(&step) == ""
+			return actionRuleMikefarahYq.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -737,12 +747,14 @@ func TestActionRuleOziProjectPublish(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "OZI-Project/publish",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "OZI-Project/publish",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleOziProjectPublish.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleOziProjectPublish.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -752,7 +764,7 @@ func TestActionRuleOziProjectPublish(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["pull-request-body"] = value
-			return actionRuleOziProjectPublish.rule.extractFrom(&step) == value
+			return actionRuleOziProjectPublish.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -760,7 +772,7 @@ func TestActionRuleOziProjectPublish(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "pull-request-body")
-			return actionRuleOziProjectPublish.rule.extractFrom(&step) == ""
+			return actionRuleOziProjectPublish.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -771,14 +783,14 @@ func TestActionRuleOziProjectPublish(t *testing.T) {
 func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 	t.Run("issue-close-message", func(t *testing.T) {
 		t.Run("Applies to", func(t *testing.T) {
-			f := func(uses gha.Uses, i uint) bool {
+			f := func(step gha.Step, i uint) bool {
 				if i%2 == 0 {
-					uses.Name = "roots/issue-closer-action"
+					step.Uses.Name = "roots/issue-closer-action"
 				} else {
-					uses.Name = "roots/issue-closer"
+					step.Uses.Name = "roots/issue-closer"
 				}
 
-				return actionRuleRootsIssueCloserActionIssueCloseMessage.appliesTo(&uses)
+				return actionRuleRootsIssueCloserActionIssueCloseMessage.appliesTo(&step)
 			}
 
 			if err := quick.Check(f, nil); err != nil {
@@ -789,7 +801,7 @@ func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 		t.Run("Extract from", func(t *testing.T) {
 			with := func(step gha.Step, value string) bool {
 				step.With["issue-close-message"] = value
-				return actionRuleRootsIssueCloserActionIssueCloseMessage.rule.extractFrom(&step) == value
+				return actionRuleRootsIssueCloserActionIssueCloseMessage.extractFrom(&step) == value
 			}
 			if err := quick.Check(with, nil); err != nil {
 				t.Error(err)
@@ -797,7 +809,7 @@ func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 
 			without := func(step gha.Step) bool {
 				delete(step.With, "issue-close-message")
-				return actionRuleRootsIssueCloserActionIssueCloseMessage.rule.extractFrom(&step) == ""
+				return actionRuleRootsIssueCloserActionIssueCloseMessage.extractFrom(&step) == ""
 			}
 			if err := quick.Check(without, nil); err != nil {
 				t.Error(err)
@@ -807,14 +819,14 @@ func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 
 	t.Run("pr-close-message", func(t *testing.T) {
 		t.Run("Applies to", func(t *testing.T) {
-			f := func(uses gha.Uses, i uint) bool {
+			f := func(step gha.Step, i uint) bool {
 				if i%2 == 0 {
-					uses.Name = "roots/issue-closer-action"
+					step.Uses.Name = "roots/issue-closer-action"
 				} else {
-					uses.Name = "roots/issue-closer"
+					step.Uses.Name = "roots/issue-closer"
 				}
 
-				return actionRuleRootsIssueCloserActionPrCloseMessage.appliesTo(&uses)
+				return actionRuleRootsIssueCloserActionPrCloseMessage.appliesTo(&step)
 			}
 
 			if err := quick.Check(f, nil); err != nil {
@@ -825,7 +837,7 @@ func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 		t.Run("Extract from", func(t *testing.T) {
 			with := func(step gha.Step, value string) bool {
 				step.With["pr-close-message"] = value
-				return actionRuleRootsIssueCloserActionPrCloseMessage.rule.extractFrom(&step) == value
+				return actionRuleRootsIssueCloserActionPrCloseMessage.extractFrom(&step) == value
 			}
 			if err := quick.Check(with, nil); err != nil {
 				t.Error(err)
@@ -833,7 +845,7 @@ func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 
 			without := func(step gha.Step) bool {
 				delete(step.With, "pr-close-message")
-				return actionRuleRootsIssueCloserActionPrCloseMessage.rule.extractFrom(&step) == ""
+				return actionRuleRootsIssueCloserActionPrCloseMessage.extractFrom(&step) == ""
 			}
 			if err := quick.Check(without, nil); err != nil {
 				t.Error(err)
@@ -844,9 +856,9 @@ func TestActionRuleRootsIssueCloserAction(t *testing.T) {
 
 func TestActionRuleSergeysovaJqAction(t *testing.T) {
 	t.Run("Applies to", func(t *testing.T) {
-		f := func(uses gha.Uses) bool {
-			uses.Name = "sergeysova/jq-action"
-			return actionRuleSergeysovaJqAction.appliesTo(&uses)
+		f := func(step gha.Step) bool {
+			step.Uses.Name = "sergeysova/jq-action"
+			return actionRuleSergeysovaJqAction.appliesTo(&step)
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -857,7 +869,7 @@ func TestActionRuleSergeysovaJqAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["cmd"] = value
-			return actionRuleSergeysovaJqAction.rule.extractFrom(&step) == value
+			return actionRuleSergeysovaJqAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -865,7 +877,7 @@ func TestActionRuleSergeysovaJqAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "cmd")
-			return actionRuleSergeysovaJqAction.rule.extractFrom(&step) == ""
+			return actionRuleSergeysovaJqAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -911,12 +923,14 @@ func TestActionRuleSonarSourceSonarqubeScanAction(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				uses := gha.Uses{
-					Name: "SonarSource/sonarqube-scan-action",
-					Ref:  tt.ref,
+				step := gha.Step{
+					Uses: gha.Uses{
+						Name: "SonarSource/sonarqube-scan-action",
+						Ref:  tt.ref,
+					},
 				}
 
-				if got, want := actionRuleSonarSourceSonarqubeScanAction.appliesTo(&uses), tt.want; got != want {
+				if got, want := actionRuleSonarSourceSonarqubeScanAction.appliesTo(&step), tt.want; got != want {
 					t.Fatalf("Unexpected result for %s (got %t, want %t)", tt.ref, got, want)
 				}
 			})
@@ -926,7 +940,7 @@ func TestActionRuleSonarSourceSonarqubeScanAction(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		with := func(step gha.Step, value string) bool {
 			step.With["args"] = value
-			return actionRuleSonarSourceSonarqubeScanAction.rule.extractFrom(&step) == value
+			return actionRuleSonarSourceSonarqubeScanAction.extractFrom(&step) == value
 		}
 		if err := quick.Check(with, nil); err != nil {
 			t.Error(err)
@@ -934,7 +948,7 @@ func TestActionRuleSonarSourceSonarqubeScanAction(t *testing.T) {
 
 		without := func(step gha.Step) bool {
 			delete(step.With, "args")
-			return actionRuleSonarSourceSonarqubeScanAction.rule.extractFrom(&step) == ""
+			return actionRuleSonarSourceSonarqubeScanAction.extractFrom(&step) == ""
 		}
 		if err := quick.Check(without, nil); err != nil {
 			t.Error(err)
@@ -972,7 +986,7 @@ func TestStepRuleRun(t *testing.T) {
 	t.Run("Extract from", func(t *testing.T) {
 		f := func(step gha.Step, run string) bool {
 			step.Run = run
-			return stepRuleRun.rule.extractFrom(&step) == run
+			return stepRuleRun.extractFrom(&step) == run
 		}
 
 		if err := quick.Check(f, nil); err != nil {
@@ -982,12 +996,10 @@ func TestStepRuleRun(t *testing.T) {
 }
 
 func TestAllRules(t *testing.T) {
-	testCases := allRules()
-
 	t.Run("id", func(t *testing.T) {
 		idExpr := regexp.MustCompile(`ADES\d{3}`)
 
-		for _, tt := range testCases {
+		for _, tt := range rules {
 			t.Run(tt.title, func(t *testing.T) {
 				t.Parallel()
 
@@ -998,8 +1010,8 @@ func TestAllRules(t *testing.T) {
 		}
 
 		t.Run("unique", func(t *testing.T) {
-			ids := make(map[string]rule, len(testCases))
-			for _, tt := range testCases {
+			ids := make(map[string]rule, len(rules))
+			for _, tt := range rules {
 				if got, ok := ids[tt.id]; ok && tt.title != got.title {
 					t.Errorf("Found repeated ID %q", tt.id)
 				}
@@ -1010,7 +1022,7 @@ func TestAllRules(t *testing.T) {
 	})
 
 	t.Run("description", func(t *testing.T) {
-		for _, tt := range testCases {
+		for _, tt := range rules {
 			t.Run(tt.id, func(t *testing.T) {
 				t.Parallel()
 
@@ -1030,7 +1042,7 @@ func TestAllRules(t *testing.T) {
 	})
 
 	t.Run("title", func(t *testing.T) {
-		for _, tt := range testCases {
+		for _, tt := range rules {
 			t.Run(tt.id, func(t *testing.T) {
 				t.Parallel()
 
@@ -1044,9 +1056,7 @@ func TestAllRules(t *testing.T) {
 
 func TestExplain(t *testing.T) {
 	t.Run("Existing rules", func(t *testing.T) {
-		testCases := allRules()
-
-		for _, tt := range testCases {
+		for _, tt := range rules {
 			t.Run(tt.id, func(t *testing.T) {
 				t.Parallel()
 
@@ -1085,9 +1095,7 @@ func TestExplain(t *testing.T) {
 
 func TestFix(t *testing.T) {
 	t.Run("Existing rules", func(t *testing.T) {
-		testCases := allRules()
-
-		for _, tt := range testCases {
+		for _, tt := range rules {
 			t.Run(tt.id, func(t *testing.T) {
 				t.Parallel()
 
@@ -1129,36 +1137,17 @@ func TestFix(t *testing.T) {
 }
 
 func TestFindRule(t *testing.T) {
-	t.Run("Action rules", func(t *testing.T) {
-		for _, tt := range actionRules {
-			t.Run(tt.rule.id, func(t *testing.T) {
+	t.Run("Existing rules", func(t *testing.T) {
+		for _, tt := range rules {
+			t.Run(tt.id, func(t *testing.T) {
 				t.Parallel()
 
-				r, err := findRule(tt.rule.id)
+				r, err := findRule(tt.id)
 				if err != nil {
-					t.Fatalf("Couldn't find rule %q", tt.rule.id)
+					t.Fatalf("Couldn't find rule %q", tt.id)
 				}
 
-				if r.id != tt.rule.id {
-					t.Errorf("Unexpected rule found: %#v", r)
-				}
-			})
-		}
-	})
-
-	t.Run("Step rules", func(t *testing.T) {
-		testCases := stepRules
-
-		for _, tt := range testCases {
-			t.Run(tt.rule.id, func(t *testing.T) {
-				t.Parallel()
-
-				r, err := findRule(tt.rule.id)
-				if err != nil {
-					t.Fatalf("Couldn't find rule %q", tt.rule.id)
-				}
-
-				if r.id != tt.rule.id {
+				if r.id != tt.id {
 					t.Errorf("Unexpected rule found: %#v", r)
 				}
 			})
@@ -1388,7 +1377,8 @@ func TestIsAtOrAfterVersion(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if got, want := isAtOrAfterVersion(&tt.uses, tt.version), tt.want; got != want {
+			step := gha.Step{Uses: tt.uses}
+			if got, want := isAtOrAfterVersion(&step, tt.version), tt.want; got != want {
 				ref := tt.uses.Ref
 				if tt.uses.Annotation != "" {
 					ref = fmt.Sprintf("%s (%s)", tt.uses.Ref, tt.uses.Annotation)
@@ -1602,7 +1592,8 @@ func TestIsBeforeVersion(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if got, want := isBeforeVersion(&tt.uses, tt.version), tt.want; got != want {
+			step := gha.Step{Uses: tt.uses}
+			if got, want := isBeforeVersion(&step, tt.version), tt.want; got != want {
 				ref := tt.uses.Ref
 				if tt.uses.Annotation != "" {
 					ref = fmt.Sprintf("%s (%s)", tt.uses.Ref, tt.uses.Annotation)
@@ -1764,17 +1755,4 @@ func TestFixReplaceIn(t *testing.T) {
 			}
 		})
 	}
-}
-
-func allRules() []rule {
-	rules := make([]rule, 0, len(actionRules)+len(stepRules))
-	for _, r := range actionRules {
-		rules = append(rules, r.rule)
-	}
-
-	for _, r := range stepRules {
-		rules = append(rules, r.rule)
-	}
-
-	return rules
 }


### PR DESCRIPTION
## Summary

This migrates part of the `appliesTo` responsibility from `analyze.go` (where it doesn't really belong) to `rules.go` (where it belongs). As a result we can merge the `actionRule` and `stepRule` into a common interface, further simplifying what users of the `rules` have to know about the interface.