### PR TITLE
Improve `analyzeString`

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -214,17 +214,19 @@ func analyzeStep(id int, step *gha.Step, matcher ExprMatcher) []Violation {
 
 func analyzeString(s string, matcher ExprMatcher) []Violation {
 	b := []byte(s)
-	if len(matcher.FindAll(stripSafe(b))) == 0 {
+	if matcher.FindAll(stripSafe(b)) == nil {
 		return nil
 	}
 
 	violations := make([]Violation, 0)
-	if matches := matcher.FindAll(b); matches != nil {
-		for _, problem := range matches {
-			violations = append(violations, Violation{
-				Problem: string(problem),
-			})
+	for _, problem := range matcher.FindAll(b) {
+		if len(matcher.FindAll(stripSafe(problem))) == 0 {
+			continue
 		}
+
+		violations = append(violations, Violation{
+			Problem: string(problem),
+		})
 	}
 
 	return violations


### PR DESCRIPTION
@codex identified this test case that is not handled correctly internally. In practice, users never see this "bug" because of [an unrelated check](https://github.com/ericcornelissen/ades/blob/14ab2529a30e67a86c0cd1a64d1e129672222cc8/analyze.go#L166) up the call chain.