### PR TITLE
Prefer dependency origins over domain-level redirects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 )
 
 require (
-	4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	fillmore-labs.com/zerolint v0.0.16 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
@@ -92,6 +91,7 @@ require (
 	github.com/kisielk/errcheck v1.9.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kunwardeep/paralleltest v1.0.15 // indirect
+	github.com/leighmcculloch/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -175,7 +175,6 @@ require (
 )
 
 tool (
-	4d63.com/gochecknoinits
 	fillmore-labs.com/zerolint
 	github.com/alexkohler/dogsled/cmd/dogsled
 	github.com/alexkohler/nakedret/v2/cmd/nakedret
@@ -191,6 +190,7 @@ tool (
 	github.com/jgautheron/goconst/cmd/goconst
 	github.com/kisielk/errcheck
 	github.com/kunwardeep/paralleltest
+	github.com/leighmcculloch/gochecknoinits
 	github.com/mdempsky/unconvert
 	github.com/nishanths/exhaustive/cmd/exhaustive
 	github.com/polyfloyd/go-errorlint

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3 h1:dA+MoC4Kt+VGJ4ZAlMLweBi1JAcYvlXwKlpJkjmC64k=
-4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3/go.mod h1:4o1i5aXtIF5tJFt3UD1knCVmWOXg7fLYdHVu6jeNcnM=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
@@ -231,6 +229,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kunwardeep/paralleltest v1.0.15 h1:ZMk4Qt306tHIgKISHWFJAO1IDQJLc6uDyJMLyncOb6w=
 github.com/kunwardeep/paralleltest v1.0.15/go.mod h1:di4moFqtfz3ToSKxhNjhOZL+696QtJGCFe132CbBLGk=
+github.com/leighmcculloch/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3 h1:SZEgKeymA/5r+g36fA43vl9KshUBbg2NbdEkZyUa7hc=
+github.com/leighmcculloch/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3/go.mod h1:hG1epyGTNHLobZoDmaRNuDk78XfVAxXZnQKs/J7Z6EI=
 github.com/liamg/memoryfs v1.6.0 h1:jAFec2HI1PgMTem5gR7UT8zi9u4BfG5jorCRlLH06W8=
 github.com/liamg/memoryfs v1.6.0/go.mod h1:z7mfqXFQS8eSeBBsFjYLlxYRMRyiPktytvYCYTb3BSk=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=

--- a/tasks.go
+++ b/tasks.go
@@ -522,7 +522,6 @@ func TaskVet(t *T) error {
 	t.Log("Vetting...")
 	return t.Exec(
 		"go vet ./...",
-		"go run 4d63.com/gochecknoinits ./...",
 		"go run fillmore-labs.com/zerolint -level=full ./...",
 		"go run github.com/alexkohler/dogsled/cmd/dogsled -set_exit_status ./...",
 		"go run github.com/alexkohler/nakedret/v2/cmd/nakedret -l 0 ./...",
@@ -537,6 +536,7 @@ func TaskVet(t *T) error {
 		"go run github.com/jgautheron/goconst/cmd/goconst -numbers -set-exit-status ./web/...",
 		"go run github.com/kisielk/errcheck ./...",
 		"go run github.com/kunwardeep/paralleltest -i -ignoreloopVar -checkcleanup ./...",
+		"go run github.com/leighmcculloch/gochecknoinits ./...",
 		"go run github.com/mdempsky/unconvert ./...",
 		"go run github.com/nishanths/exhaustive/cmd/exhaustive ./...",
 		"go run github.com/polyfloyd/go-errorlint ./...",


### PR DESCRIPTION
## Summary

Replace dependencies that are on a "custom" domain which just redirects to a repository. The motivation for avoiding this is that if the domain expires it enables attacks (the argument against is that it's more involved to upgrade when the repository is moved).

- Replace `4d63.com` by `github.com/leighmcculloch` per <https://4d63.com/gochecknoinits/>