### PR TITLE
Run `go fix` as part of vetting

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -261,7 +261,6 @@ func TaskFormat(t *T) error {
 	t.Log("Formatting...")
 	return t.Exec(
 		"gofmt -w .",
-		"gofmt -w -r 'interface{} -> any' .",
 		"go mod tidy",
 		"go run golang.org/x/tools/cmd/goimports -w .",
 	)
@@ -522,6 +521,7 @@ func TaskVet(t *T) error {
 	t.Log("Vetting...")
 	return t.Exec(
 		"go vet ./...",
+		"go fix -diff ./...",
 		"go run 4d63.com/gochecknoinits ./...",
 		"go run fillmore-labs.com/zerolint -level=full ./...",
 		"go run github.com/alexkohler/dogsled/cmd/dogsled -set_exit_status ./...",


### PR DESCRIPTION
Based on <https://rednafi.com/go/gofix/>.