### PR TITLE
Replace `ncipollo/release-action` by `gh release create`

### DIFF
--- a/.github/workflows/gha.sum
+++ b/.github/workflows/gha.sum
@@ -11,5 +11,4 @@ docker/login-action@v4.6.0 O5qlbXujgHyM0C88TlipKNBtXRMhlwBCKRUCgvC1nGY=
 docker/setup-buildx-action@v4.2.0 OUF6tU3l19j2zwFVn3YeYoxw6uHcf0uOSeKF+hndv6g=
 github/codeql-action@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 5dzXvuQue0AhL9y0GOGacHnZlDms9ediiMt+tQJJgo8=
 github/codeql-action@v4.37.0 5dzXvuQue0AhL9y0GOGacHnZlDms9ediiMt+tQJJgo8=
-ncipollo/release-action@v1.21.0 BVxEx9pIhil9GqSTP9yGXoMhmlS7hjzYhAvL4fJfpyQ=
 sigstore/cosign-installer@v4.1.0 BrsAnwKWGWKPxPE4FeM5H+IX8IEsObRDjxuAqaMZVOo=

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,22 +91,29 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v7.0.0
       with:
+        cache: false
         go-version-file: go.mod
     - name: Get release version
       id: version
       shell: bash
       run: |
-        echo "version=${GITHUB_REF#refs/tags/}" >>"$GITHUB_OUTPUT"
+        value=${GITHUB_REF#refs/tags/}
+        echo "value=${value}" >>"${GITHUB_OUTPUT}"
     - name: Compile
       run: go run tasks.go build-all
     - name: Create GitHub release
-      uses: ncipollo/release-action@v1.21.0
-      with:
-        tag: ${{ steps.version.outputs.version }}
-        name: Release ${{ steps.version.outputs.version }}
-        body: ${{ steps.version.outputs.version }}
-        artifacts: ./_compiled/*
-        immutableCreate: true
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.version.outputs.value }}
+      run: |
+        gh release create "${VERSION}" ./_compiled/* \
+          --title "Release ${VERSION}" \
+          --notes "${VERSION}" \
+          --draft=false \
+          --latest=true \
+          --generate-notes=false \
+          --prerelease=false
     - name: Attest build provenance
       uses: actions/attest@v4.2.0
       with:


### PR DESCRIPTION
Closes #748
Based on https://github.com/chains-project/ghasum/pull/437 (which was used to create [ghasum release v0.6.4](https://github.com/chains-project/ghasum/releases/tag/v0.6.4))